### PR TITLE
Helper functions for rdm discovery response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-  SRCS "src/esp_dmx.c" "src/esp_rdm.c"
+  SRCS "src/esp_dmx.c" "src/esp_rdm.c" "src/esp_rdm_client.c" 
   INCLUDE_DIRS "src" 
 )   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-  SRCS "src/esp_dmx.c" "src/esp_rdm.c" "src/esp_rdm_client.c" 
+  SRCS "src/esp_dmx.c" "src/esp_rdm.c" "src/esp_rdm_client.c" "src/private/rdm_encode/functions.c"
   INCLUDE_DIRS "src" 
 )   

--- a/examples/idf_rdm/CMakeLists.txt
+++ b/examples/idf_rdm/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "idf_rdm_discovery_response.c"
+    INCLUDE_DIRS ""
+)

--- a/examples/idf_rdm/idf_rdm_discovery_response.c
+++ b/examples/idf_rdm/idf_rdm_discovery_response.c
@@ -12,7 +12,7 @@
 static const char *TAG = "main";
 static uint8_t data[DMX_MAX_PACKET_SIZE] = {};
 
-void handleRdmEvent(const dmx_event_t *event, const void *data, const uint16_t size);
+void handleRdmEvent(const dmx_packet_t *dmxPacket, const void *data, const uint16_t size);
 
 void dmxTask(void *unused)
 {
@@ -21,29 +21,29 @@ void dmxTask(void *unused)
 
     while (true)
     {
-        dmx_event_t event;
+        dmx_packet_t dmxPacket;
         size_t ret = 0;
-        ret = dmx_receive(DMX_NUM_2, &event, DMX_TIMEOUT_TICK);
+        ret = dmx_receive(DMX_NUM_2, &dmxPacket, DMX_TIMEOUT_TICK);
         if (ret)
         {
-            if (event.err == ESP_OK)
+            if (dmxPacket.err == ESP_OK)
             {
-                if (event.is_rdm)
+                if (dmxPacket.is_rdm)
                 {
-                    dmx_read(DMX_NUM_2, data, event.size);
-                    handleRdmEvent(&event, data, event.size);
+                    dmx_read(DMX_NUM_2, data, dmxPacket.size);
+                    handleRdmEvent(&dmxPacket, data, dmxPacket.size);
                 }
             }
             else
             {
-                ESP_LOGE(TAG, "dmx error: %s", esp_err_to_name(event.err));
+                ESP_LOGE(TAG, "dmx error: %s", esp_err_to_name(dmxPacket.err));
             }
         }
     }
 }
 
 
-void handleRdmEvent(const dmx_event_t *event, const void *data, const uint16_t size)
+void handleRdmEvent(const dmx_packet_t *dmxPacket, const void *data, const uint16_t size)
 {
     rdm_header_t header;
     if (rdm_get_header(&header, data))

--- a/examples/idf_rdm/idf_rdm_discovery_response.c
+++ b/examples/idf_rdm/idf_rdm_discovery_response.c
@@ -1,0 +1,93 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "esp_dmx.h"
+#include "esp_log.h"
+#include "esp_system.h"
+
+#define TX_PIN 17 // the pin we are using to TX with
+#define RX_PIN 16 // the pin we are using to RX with
+#define EN_PIN 21 // the pin we are using to enable TX on the DMX transceiver
+
+static const char *TAG = "main";
+static uint8_t data[DMX_MAX_PACKET_SIZE] = {};
+
+void handleRdmEvent(const dmx_event_t *event, const void *data, const uint16_t size);
+
+void dmxTask(void *unused)
+{
+    ESP_ERROR_CHECK(dmx_set_pin(DMX_NUM_2, TX_PIN, RX_PIN, EN_PIN));
+    ESP_ERROR_CHECK(dmx_driver_install(DMX_NUM_2, DMX_DEFAULT_INTR_FLAGS));
+
+    while (true)
+    {
+        dmx_event_t event;
+        size_t ret = 0;
+        ret = dmx_receive(DMX_NUM_2, &event, DMX_TIMEOUT_TICK);
+        if (ret)
+        {
+            if (event.err == ESP_OK)
+            {
+                if (event.is_rdm)
+                {
+                    dmx_read(DMX_NUM_2, data, event.size);
+                    handleRdmEvent(&event, data, event.size);
+                }
+            }
+            else
+            {
+                ESP_LOGE(TAG, "dmx error: %s", esp_err_to_name(event.err));
+            }
+        }
+    }
+}
+
+
+void handleRdmEvent(const dmx_event_t *event, const void *data, const uint16_t size)
+{
+    rdm_header_t header;
+    if (rdm_get_header(&header, data))
+    {
+        if (rdm_is_directed_at_us(DMX_NUM_2, &header))
+        {
+            if (header.cc == RDM_CC_DISC_COMMAND)
+            {
+                if (header.pid == RDM_PID_DISC_UNIQUE_BRANCH)
+                {
+                    const rdm_uid_t lowUid = buf_to_uid(data + 24);
+                    const rdm_uid_t highUid = buf_to_uid(data + 30);
+                    const rdm_uid_t ourUid = rdm_get_uid(DMX_NUM_2);
+
+                    if (!rdm_is_muted(DMX_NUM_2) && lowUid <= ourUid && ourUid <= highUid)
+                    {
+                        const size_t respSize = rdm_send_disc_response(DMX_NUM_2, 7, ourUid);
+                        ESP_LOGI("RDM", "Sent discovery response. %d bytes", respSize);
+                    }
+                }
+                else if (header.pid == RDM_PID_DISC_UN_MUTE)
+                {
+                    ESP_LOGI("RDM", "Received UNMUTE");
+                    rdm_set_muted(DMX_NUM_2, false);
+                    //TODO add response for unmute
+
+                }
+                else if (header.pid == RDM_PID_DISC_MUTE)
+                {
+                    ESP_LOGI("RDM", "Received MUTE");
+                    rdm_set_muted(DMX_NUM_2, true);
+                    const size_t bytesSent = rdm_send_mute_response(DMX_NUM_2, header.source_uid, header.tn);
+                }
+            }
+        }
+    }
+}
+
+void app_main()
+{
+    TaskHandle_t dmxTaskHandle = NULL;
+    xTaskCreatePinnedToCore(dmxTask, "DMX_TASK", 10240, NULL, 2, &dmxTaskHandle, 1);
+    if (!dmxTaskHandle)
+    {
+        ESP_LOGE(TAG, "Failed to create dmx task");
+    }
+}

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -71,6 +71,20 @@ bool rdm_is_muted(dmx_port_t dmx_num) {
   return is_muted;
 }
 
+bool rdm_set_muted(dmx_port_t dmx_num, bool muted) {
+  RDM_CHECK(dmx_num < DMX_NUM_MAX, false, "dmx_num error");
+  RDM_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
+
+  spinlock_t *const restrict spinlock = &dmx_spinlock[dmx_num];
+  dmx_driver_t *const driver = dmx_driver[dmx_num];
+
+  taskENTER_CRITICAL(spinlock);
+  driver->rdm.discovery_is_muted = muted;
+  taskEXIT_CRITICAL(spinlock);
+  return true;
+}
+
+
 size_t rdm_send_disc_response(dmx_port_t dmx_num, size_t preamble_len,
                               rdm_uid_t uid) {
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -18,9 +18,10 @@
 #define RDM_CHECK(a, err_code, format, ...) \
   ESP_RETURN_ON_FALSE(a, err_code, TAG, format, ##__VA_ARGS__)
 
-static const char *TAG = "rdm";  // The log tagline for the file.
+static const char *TAG = "rdm"; // The log tagline for the file.
 
-rdm_uid_t rdm_get_uid(dmx_port_t dmx_num) {
+rdm_uid_t rdm_get_uid(dmx_port_t dmx_num)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
@@ -29,8 +30,10 @@ rdm_uid_t rdm_get_uid(dmx_port_t dmx_num) {
 
   // Initialize the RDM UID
   taskENTER_CRITICAL(spinlock);
-  if (driver->rdm.uid == 0) {
-    struct __attribute__((__packed__)) {
+  if (driver->rdm.uid == 0)
+  {
+    struct __attribute__((__packed__))
+    {
       uint16_t manufacturer;
       uint64_t device;
     } mac;
@@ -44,7 +47,8 @@ rdm_uid_t rdm_get_uid(dmx_port_t dmx_num) {
   return uid;
 }
 
-void rdm_set_uid(dmx_port_t dmx_num, rdm_uid_t uid) {
+void rdm_set_uid(dmx_port_t dmx_num, rdm_uid_t uid)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, , "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), , "driver is not installed");
   RDM_CHECK(uid <= RDM_MAX_UID, , "uid error");
@@ -57,7 +61,8 @@ void rdm_set_uid(dmx_port_t dmx_num, rdm_uid_t uid) {
   taskEXIT_CRITICAL(spinlock);
 }
 
-bool rdm_is_muted(dmx_port_t dmx_num) {
+bool rdm_is_muted(dmx_port_t dmx_num)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, false, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
@@ -72,7 +77,8 @@ bool rdm_is_muted(dmx_port_t dmx_num) {
   return is_muted;
 }
 
-bool rdm_set_muted(dmx_port_t dmx_num, bool muted) {
+bool rdm_set_muted(dmx_port_t dmx_num, bool muted)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, false, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
@@ -85,9 +91,9 @@ bool rdm_set_muted(dmx_port_t dmx_num, bool muted) {
   return true;
 }
 
-
 size_t rdm_send_disc_response(dmx_port_t dmx_num, size_t preamble_len,
-                              rdm_uid_t uid) {
+                              rdm_uid_t uid)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(preamble_len <= 7, 0, "preamble_len error");
@@ -105,10 +111,9 @@ size_t rdm_send_disc_response(dmx_port_t dmx_num, size_t preamble_len,
   return written;
 }
 
-
 size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_disc_mute_t *mute_params)
 {
-  //TODO add support for Control Field and Binding UID
+  // TODO add support for Control Field and Binding UID
 
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
@@ -120,20 +125,20 @@ size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, con
 
   // Prepare the RDM message
   rdm_data_t *rdm = (rdm_data_t *)driver->data.buffer;
-  
+
   // set control field
   size_t written = rdm_encode_mute(&rdm->pd, mute_params);
 
   rdm_header_t header = {
       .destination_uid = uid,
       .source_uid = rdm_get_uid(dmx_num),
-      .tn = tn, 
+      .tn = tn,
       .port_id = dmx_num + 1,
       .message_count = 0,
       .sub_device = 0,
       .cc = RDM_CC_DISC_COMMAND_RESPONSE,
       .pid = RDM_PID_DISC_MUTE,
-      .pdl = 0x02, 
+      .pdl = 0x02,
   };
   written += rdm_encode_header(rdm, &header);
   const size_t sent = dmx_send(dmx_num, written);
@@ -144,7 +149,8 @@ size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, con
 
 size_t rdm_send_disc_unique_branch(dmx_port_t dmx_num,
                                    rdm_disc_unique_branch_t *params,
-                                   rdm_response_t *response, rdm_uid_t *uid) {
+                                   rdm_response_t *response, rdm_uid_t *uid)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(params != NULL, 0, "params is null");
@@ -177,28 +183,36 @@ size_t rdm_send_disc_unique_branch(dmx_port_t dmx_num,
   size_t num_params = 0;
   dmx_packet_t event;
   const size_t read = dmx_receive(dmx_num, &event, DMX_TIMEOUT_TICK);
-  if (!read) {
-    if (response != NULL) {
+  if (!read)
+  {
+    if (response != NULL)
+    {
       response->err = event.err;
       response->type = RDM_RESPONSE_TYPE_NONE;
       response->num_params = 0;
     }
-  } else {
+  }
+  else
+  {
     // Check the packet for errors
     esp_err_t err;
     rdm_response_type_t response_type;
-    if (!rdm_decode_disc_response(driver->data.buffer, uid)) {
+    if (!rdm_decode_disc_response(driver->data.buffer, uid))
+    {
       err = ESP_ERR_INVALID_CRC;
       response_type = RDM_RESPONSE_TYPE_NONE;
       *uid = 0;
-    } else {
+    }
+    else
+    {
       err = ESP_OK;
       response_type = RDM_RESPONSE_TYPE_ACK;
       num_params = 1;
     }
 
     // Report response back to user
-    if (response != NULL) {
+    if (response != NULL)
+    {
       response->err = err;
       response->type = response_type;
       response->num_params = num_params;
@@ -210,7 +224,8 @@ size_t rdm_send_disc_unique_branch(dmx_port_t dmx_num,
 }
 
 size_t rdm_send_disc_mute(dmx_port_t dmx_num, rdm_uid_t uid, bool mute,
-                          rdm_response_t *response, rdm_disc_mute_t *params) {
+                          rdm_response_t *response, rdm_disc_mute_t *params)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
@@ -239,48 +254,66 @@ size_t rdm_send_disc_mute(dmx_port_t dmx_num, rdm_uid_t uid, bool mute,
 
   // Determine if a response is expected
   size_t num_params = 0;
-  if (!RDM_UID_IS_BROADCAST(uid)) {
+  if (!RDM_UID_IS_BROADCAST(uid))
+  {
     // Receive the response
     dmx_packet_t event;
     const size_t read = dmx_receive(dmx_num, &event, DMX_TIMEOUT_TICK);
-    if (!read) {
-      if (response != NULL) {
+    if (!read)
+    {
+      if (response != NULL)
+      {
         response->err = event.err;
         response->type = RDM_RESPONSE_TYPE_NONE;
         response->num_params = 0;
       }
-    } else {
+    }
+    else
+    {
       // Check the packet for errors
       esp_err_t err;
-      if (!rdm_decode_header(driver->data.buffer, &header)) {
+      if (!rdm_decode_header(driver->data.buffer, &header))
+      {
         err = ESP_ERR_INVALID_RESPONSE;
-      } else if (!header.checksum_is_valid) {
+      }
+      else if (!header.checksum_is_valid)
+      {
         err = ESP_ERR_INVALID_CRC;
-      } else {
+      }
+      else
+      {
         err = ESP_OK;
       }
       // TODO: error checking of packet -- check pid, cc
 
       // Decode the response
-      if (header.response_type == RDM_RESPONSE_TYPE_ACK) {
-        if (params != NULL) {
+      if (header.response_type == RDM_RESPONSE_TYPE_ACK)
+      {
+        if (params != NULL)
+        {
           rdm_decode_mute(&rdm->pd, params, 1, header.pdl);
         }
         num_params = 1;
-      } else {
+      }
+      else
+      {
         // Discovery commands do not accept any other response type
         err = ESP_ERR_INVALID_RESPONSE;
       }
 
       // Report response back to user
-      if (response != NULL) {
+      if (response != NULL)
+      {
         response->err = err;
         response->type = header.response_type;
         response->num_params = num_params;
       }
     }
-  } else {
-    if (response != NULL) {
+  }
+  else
+  {
+    if (response != NULL)
+    {
       response->err = ESP_OK;
       response->type = RDM_RESPONSE_TYPE_NONE;
       response->num_params = 0;
@@ -293,7 +326,8 @@ size_t rdm_send_disc_mute(dmx_port_t dmx_num, rdm_uid_t uid, bool mute,
 }
 
 size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
-                                  void *context) {
+                                  void *context)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
@@ -301,12 +335,13 @@ size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
 #ifndef CONFIG_RDM_STATIC_DEVICE_DISCOVERY
   rdm_disc_unique_branch_t *stack;
   stack = malloc(sizeof(rdm_disc_unique_branch_t) * 49);
-  if (stack == NULL) {
+  if (stack == NULL)
+  {
     ESP_LOGE(TAG, "Discovery malloc error");
     return 0;
   }
 #else
-  rdm_disc_unique_branch_t stack[49];  // 784B - use with caution!
+  rdm_disc_unique_branch_t stack[49]; // 784B - use with caution!
 #endif
 
   dmx_driver_t *restrict const driver = dmx_driver[dmx_num];
@@ -321,37 +356,46 @@ size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
   stack[0].upper_bound = RDM_MAX_UID;
 
   size_t num_found = 0;
-  while (stack_size > 0) {
+  while (stack_size > 0)
+  {
     rdm_disc_unique_branch_t *branch = &stack[--stack_size];
     size_t attempts = 0;
     rdm_response_t response;
     rdm_uid_t uid;
 
-    if (branch->lower_bound == branch->upper_bound) {
+    if (branch->lower_bound == branch->upper_bound)
+    {
       // Can't branch further so attempt to mute the device
       uid = branch->lower_bound;
       rdm_disc_mute_t mute;
-      do {
+      do
+      {
         rdm_send_disc_mute(dmx_num, uid, true, &response, &mute);
       } while (response.num_params == 0 && ++attempts < 3);
 
       // Attempt to fix possible error where responder is flipping its own UID
-      if (response.num_params == 0) {
-        uid = bswap64(uid) >> 16;  // Flip UID
+      if (response.num_params == 0)
+      {
+        uid = bswap64(uid) >> 16; // Flip UID
         rdm_send_disc_mute(dmx_num, uid, true, &response, &mute);
       }
 
       // Call the callback function and report a device has been found
-      if (response.num_params > 0 && !response.err) {
+      if (response.num_params > 0 && !response.err)
+      {
         cb(dmx_num, uid, num_found, &mute, context);
         ++num_found;
       }
-    } else {
+    }
+    else
+    {
       // Search the current branch in the RDM address space
-      do {
+      do
+      {
         rdm_send_disc_unique_branch(dmx_num, branch, &response, &uid);
       } while (response.num_params == 0 && ++attempts < 3);
-      if (response.num_params > 0) {
+      if (response.num_params > 0)
+      {
         bool devices_remaining = true;
 
 #ifndef CONFIG_RDM_DEBUG_DEVICE_DISCOVERY
@@ -361,31 +405,39 @@ size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
         should not be called as it can hide bugs in the discovery algorithm.
         Users can use the sdkconfig to enable or disable discovery debugging.
         */
-        if (!response.err) {
-          for (int quick_finds = 0; quick_finds < 3; ++quick_finds) {
+        if (!response.err)
+        {
+          for (int quick_finds = 0; quick_finds < 3; ++quick_finds)
+          {
             // Attempt to mute the device
             attempts = 0;
             rdm_disc_mute_t mute;
-            do {
+            do
+            {
               rdm_send_disc_mute(dmx_num, uid, true, &response, &mute);
             } while (response.num_params == 0 && ++attempts < 3);
 
             // Call the callback function and report a device has been found
-            if (response.num_params > 0) {
+            if (response.num_params > 0)
+            {
               cb(dmx_num, uid, num_found, &mute, context);
               ++num_found;
             }
 
             // Check if there are more devices in this branch
             attempts = 0;
-            do {
+            do
+            {
               rdm_send_disc_unique_branch(dmx_num, branch, &response, &uid);
             } while (response.num_params == 0 && ++attempts < 3);
-            if (response.num_params > 0 && response.err) {
+            if (response.num_params > 0 && response.err)
+            {
               // There are more devices in this branch - branch further
               devices_remaining = true;
               break;
-            } else {
+            }
+            else
+            {
               // There are no more devices in this branch
               devices_remaining = false;
               break;
@@ -395,7 +447,8 @@ size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
 #endif
 
         // Recursively search the next two RDM address spaces
-        if (devices_remaining) {
+        if (devices_remaining)
+        {
           const rdm_uid_t lower_bound = branch->lower_bound;
           const rdm_uid_t mid = (lower_bound + branch->upper_bound) / 2;
 
@@ -421,21 +474,25 @@ size_t rdm_discover_with_callback(dmx_port_t dmx_num, rdm_discovery_cb_t cb,
   return num_found;
 }
 
-struct rdm_disc_default_ctx {
+struct rdm_disc_default_ctx
+{
   size_t size;
   rdm_uid_t *uids;
 };
 
 static void rdm_disc_cb(dmx_port_t dmx_num, rdm_uid_t uid, size_t num_found,
-                        rdm_disc_mute_t *mute, void *context) {
+                        rdm_disc_mute_t *mute, void *context)
+{
   struct rdm_disc_default_ctx *c = (struct rdm_disc_default_ctx *)context;
-  if (num_found < c->size && c->uids != NULL) {
+  if (num_found < c->size && c->uids != NULL)
+  {
     c->uids[num_found] = uid;
   }
 }
 
 size_t rdm_discover_devices_simple(dmx_port_t dmx_num, rdm_uid_t *uids,
-                                   const size_t size) {
+                                   const size_t size)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
@@ -451,7 +508,8 @@ static size_t rdm_send_generic_request(
     size_t (*encode)(void *, const void *, size_t), void *encode_params,
     size_t num_encode_params,
     size_t (*decode)(const void *, void *, size_t, size_t), void *decode_params,
-    size_t num_decode_params, rdm_response_t *response) {
+    size_t num_decode_params, rdm_response_t *response)
+{
   // Take mutex so driver values may be accessed
   dmx_driver_t *const driver = dmx_driver[dmx_num];
   xSemaphoreTakeRecursive(driver->mux, portMAX_DELAY);
@@ -461,9 +519,12 @@ static size_t rdm_send_generic_request(
   const uint8_t tn = driver->rdm.tn;
   rdm_data_t *const rdm = (rdm_data_t *)driver->data.buffer;
   size_t written;
-  if (encode && encode_params && num_encode_params) {
+  if (encode && encode_params && num_encode_params)
+  {
     written = encode(&rdm->pd, encode_params, num_encode_params);
-  } else {
+  }
+  else
+  {
     written = 0;
   }
   rdm_header_t header = {.destination_uid = uid,
@@ -480,71 +541,102 @@ static size_t rdm_send_generic_request(
 
   // Receive and decode the RDM response
   uint32_t return_val = 0;
-  if (!RDM_UID_IS_BROADCAST(uid)) {
+  if (!RDM_UID_IS_BROADCAST(uid))
+  {
     dmx_packet_t event;
     const size_t read = dmx_receive(dmx_num, &event, pdMS_TO_TICKS(20));
-    if (!read) {
-      if (response != NULL) {
+    if (!read)
+    {
+      if (response != NULL)
+      {
         response->err = event.err;
         response->type = RDM_RESPONSE_TYPE_NONE;
         response->num_params = 0;
       }
-    } else {
+    }
+    else
+    {
       // Parse the response to ensure it is valid
       esp_err_t err;
-      if (!rdm_decode_header(driver->data.buffer, &header)) {
+      if (!rdm_decode_header(driver->data.buffer, &header))
+      {
         err = ESP_ERR_INVALID_RESPONSE;
-      } else if (!header.checksum_is_valid) {
+      }
+      else if (!header.checksum_is_valid)
+      {
         err = ESP_ERR_INVALID_CRC;
-      } else if (header.destination_uid != rdm_get_uid(dmx_num)) {
+      }
+      else if (header.destination_uid != rdm_get_uid(dmx_num))
+      {
         err = ESP_ERR_INVALID_RESPONSE;
-      } else {
+      }
+      else
+      {
         err = ESP_OK;
       }
 
       // Handle the parameter data
       uint32_t response_val;
-      if (header.cc == cc + 1 && header.pid == pid) {
-        if (header.response_type == RDM_RESPONSE_TYPE_ACK) {
+      if (header.cc == cc + 1 && header.pid == pid)
+      {
+        if (header.response_type == RDM_RESPONSE_TYPE_ACK)
+        {
           // Decode the parameter data
-          if (decode) {
+          if (decode)
+          {
             // Return the number of params available when response is received
             return_val =
                 decode(&rdm->pd, decode_params, num_decode_params, header.pdl);
             response_val = return_val;
-          } else {
+          }
+          else
+          {
             // Return true when no response parameters are expected
             return_val = true;
             response_val = 0;
           }
-        } else if (header.response_type == RDM_RESPONSE_TYPE_ACK_TIMER) {
+        }
+        else if (header.response_type == RDM_RESPONSE_TYPE_ACK_TIMER)
+        {
           // Get the estimated response time and convert it to FreeRTOS ticks
           rdm_decode_16bit(&rdm->pd, &response_val, 1, header.pdl);
           response_val = pdMS_TO_TICKS(response_val * 10);
-        } else if (header.response_type == RDM_RESPONSE_TYPE_NACK_REASON) {
+        }
+        else if (header.response_type == RDM_RESPONSE_TYPE_NACK_REASON)
+        {
           // Report the NACK reason
           rdm_decode_16bit(&rdm->pd, &response_val, 1, header.pdl);
-        } else if (header.response_type == RDM_RESPONSE_TYPE_ACK_OVERFLOW) {
+        }
+        else if (header.response_type == RDM_RESPONSE_TYPE_ACK_OVERFLOW)
+        {
           // TODO: implement overflow support
           err = ESP_ERR_NOT_SUPPORTED;
-        } else {
+        }
+        else
+        {
           // An unknown response type was received
           err = ESP_ERR_INVALID_RESPONSE;
         }
-      } else {
+      }
+      else
+      {
         // The received CC and PID are invalid
         err = ESP_ERR_INVALID_RESPONSE;
       }
 
       // Report response back to user
-      if (response != NULL) {
+      if (response != NULL)
+      {
         response->err = err;
         response->type = header.response_type;
         response->num_params = response_val;
       }
     }
-  } else {
-    if (response != NULL) {
+  }
+  else
+  {
+    if (response != NULL)
+    {
       response->err = ESP_OK;
       response->type = RDM_RESPONSE_TYPE_NONE;
       response->num_params = 0;
@@ -559,7 +651,8 @@ static size_t rdm_send_generic_request(
 size_t rdm_get_supported_parameters(dmx_port_t dmx_num, rdm_uid_t uid,
                                     rdm_sub_device_t sub_device,
                                     rdm_response_t *response, rdm_pid_t *pids,
-                                    size_t size) {
+                                    size_t size)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(!RDM_UID_IS_BROADCAST(uid), 0, "uid cannot be broadcast");
@@ -571,7 +664,8 @@ size_t rdm_get_supported_parameters(dmx_port_t dmx_num, rdm_uid_t uid,
 size_t rdm_get_device_info(dmx_port_t dmx_num, rdm_uid_t uid,
                            rdm_sub_device_t sub_device,
                            rdm_response_t *response,
-                           rdm_device_info_t *device_info) {
+                           rdm_device_info_t *device_info)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(!RDM_UID_IS_BROADCAST(uid), 0, "uid cannot be broadcast");
@@ -584,7 +678,8 @@ size_t rdm_get_device_info(dmx_port_t dmx_num, rdm_uid_t uid,
 size_t rdm_get_software_version_label(dmx_port_t dmx_num, rdm_uid_t uid,
                                       rdm_sub_device_t sub_device,
                                       rdm_response_t *response, char *label,
-                                      size_t size) {
+                                      size_t size)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(!RDM_UID_IS_BROADCAST(uid), 0, "uid cannot be broadcast");
@@ -595,7 +690,8 @@ size_t rdm_get_software_version_label(dmx_port_t dmx_num, rdm_uid_t uid,
 
 size_t rdm_get_dmx_start_address(dmx_port_t dmx_num, rdm_uid_t uid,
                                  rdm_sub_device_t sub_device,
-                                 rdm_response_t *response, int *start_address) {
+                                 rdm_response_t *response, int *start_address)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(!RDM_UID_IS_BROADCAST(uid), 0, "uid cannot be broadcast");
@@ -607,7 +703,8 @@ size_t rdm_get_dmx_start_address(dmx_port_t dmx_num, rdm_uid_t uid,
 
 bool rdm_set_dmx_start_address(dmx_port_t dmx_num, rdm_uid_t uid,
                                rdm_sub_device_t sub_device,
-                               rdm_response_t *response, int start_address) {
+                               rdm_response_t *response, int start_address)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(start_address > 0 && start_address < DMX_MAX_PACKET_SIZE, 0,
@@ -619,7 +716,8 @@ bool rdm_set_dmx_start_address(dmx_port_t dmx_num, rdm_uid_t uid,
 
 size_t rdm_get_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                                rdm_sub_device_t sub_device,
-                               rdm_response_t *response, bool *identify) {
+                               rdm_response_t *response, bool *identify)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   RDM_CHECK(!RDM_UID_IS_BROADCAST(uid), 0, "uid cannot be broadcast");
@@ -631,7 +729,8 @@ size_t rdm_get_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
 
 bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                              rdm_sub_device_t sub_device,
-                             rdm_response_t *response, bool identify) {
+                             rdm_response_t *response, bool identify)
+{
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
   return rdm_send_generic_request(dmx_num, uid, sub_device, RDM_CC_SET_COMMAND,
@@ -639,20 +738,19 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                                   &identify, 1, NULL, NULL, 0, response);
 }
 
-bool rdm_get_header(rdm_header_t* header, const void* data)
+bool rdm_get_header(rdm_header_t *header, const void *data)
 {
-    return rdm_decode_header(data, header);
+  return rdm_decode_header(data, header);
 }
 
-bool rdm_is_directed_at_us(dmx_port_t dmx_num, rdm_header_t* header)
+bool rdm_is_directed_at_us(dmx_port_t dmx_num, rdm_header_t *header)
 {
 
-    return header->destination_uid == RDM_BROADCAST_ALL_UID || 
-           header->destination_uid == rdm_get_uid(dmx_num);
-
+  return header->destination_uid == RDM_BROADCAST_ALL_UID ||
+         header->destination_uid == rdm_get_uid(dmx_num);
 }
 
-size_t rdm_send_device_info_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_device_info_t *device_info)
+size_t rdm_send_get_param_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_pid_t pid, uint16_t sub_device, const void *pd, size_t pdl)
 {
   RDM_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   RDM_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
@@ -665,25 +763,25 @@ size_t rdm_send_device_info_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t 
   rdm_data_t *rdm = (rdm_data_t *)driver->data.buffer;
 
   // Write and send the response
-  const size_t pdl = rdm_encode_device_info_(&rdm->pd, device_info);
+  memcpy(&rdm->pd, pd, pdl);
   size_t written = pdl;
 
   rdm_header_t header = {
       .destination_uid = uid,
       .source_uid = rdm_get_uid(dmx_num),
-      .tn = tn, 
+      .tn = tn,
       .port_id = RDM_RESPONSE_TYPE_ACK,
       .message_count = 0,
-      .sub_device = 0,
+      .sub_device = sub_device,
       .cc = RDM_CC_GET_COMMAND_RESPONSE,
-      .pid = RDM_PID_DEVICE_INFO,
-      .pdl = pdl, 
+      .pid = pid,
+      .pdl = pdl,
   };
   written += rdm_encode_header(rdm, &header);
   const size_t sent = dmx_send(dmx_num, written);
 
   xSemaphoreGiveRecursive(driver->mux);
-  return sent;     
+  return sent;
 }
 
 size_t rdm_send_idenfiy_device_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_sub_device_t sub_device, bool identify)
@@ -706,22 +804,22 @@ size_t rdm_send_idenfiy_device_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8
   rdm_header_t header = {
       .destination_uid = uid,
       .source_uid = rdm_get_uid(dmx_num),
-      .tn = tn, 
-       // For Responder generated messages (GET_COMMAND_RESPONSE,
-       // SET_COMMAND_RESPONSE, and DISCOVERY_COMMAND_RESPONSE), this field is used
-       // as the Response Type field.
+      .tn = tn,
+      // For Responder generated messages (GET_COMMAND_RESPONSE,
+      // SET_COMMAND_RESPONSE, and DISCOVERY_COMMAND_RESPONSE), this field is used
+      // as the Response Type field.
       .port_id = RDM_RESPONSE_TYPE_ACK,
       .message_count = 0,
       .sub_device = sub_device,
       .cc = RDM_CC_GET_COMMAND_RESPONSE,
       .pid = RDM_PID_IDENTIFY_DEVICE,
-      .pdl = pdl, 
+      .pdl = pdl,
   };
   written += rdm_encode_header(rdm, &header);
   const size_t sent = dmx_send(dmx_num, written);
 
   xSemaphoreGiveRecursive(driver->mux);
-  return sent;     
+  return sent;
 }
 
 size_t rdm_send_set_command_ack_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_sub_device_t sub_device, rdm_pid_t pid)
@@ -739,21 +837,20 @@ size_t rdm_send_set_command_ack_response(dmx_port_t dmx_num, rdm_uid_t uid, uint
   rdm_header_t header = {
       .destination_uid = uid,
       .source_uid = rdm_get_uid(dmx_num),
-      .tn = tn, 
-       // For Responder generated messages (GET_COMMAND_RESPONSE,
-       // SET_COMMAND_RESPONSE, and DISCOVERY_COMMAND_RESPONSE), this field is used
-       // as the Response Type field.
+      .tn = tn,
+      // For Responder generated messages (GET_COMMAND_RESPONSE,
+      // SET_COMMAND_RESPONSE, and DISCOVERY_COMMAND_RESPONSE), this field is used
+      // as the Response Type field.
       .port_id = RDM_RESPONSE_TYPE_ACK,
       .message_count = 0,
       .sub_device = sub_device,
       .cc = RDM_CC_SET_COMMAND_RESPONSE,
       .pid = pid,
-      .pdl = 0, 
+      .pdl = 0,
   };
   const size_t written = rdm_encode_header(rdm, &header);
   const size_t sent = dmx_send(dmx_num, written);
 
   xSemaphoreGiveRecursive(driver->mux);
-  return sent;      
+  return sent;
 }
-

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -106,7 +106,7 @@ size_t rdm_send_disc_response(dmx_port_t dmx_num, size_t preamble_len,
 }
 
 
-size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn)
+size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_disc_mute_t *mute_params)
 {
   //TODO add support for Control Field and Binding UID
 
@@ -122,9 +122,7 @@ size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn)
   rdm_data_t *rdm = (rdm_data_t *)driver->data.buffer;
   
   // set control field
-  const uint16_t control_field = 0;
-  memcpy(&rdm->pd, &control_field, sizeof(control_field));
-  size_t written = sizeof(control_field); 
+  size_t written = rdm_encode_mute(&rdm->pd, mute_params);
 
   rdm_header_t header = {
       .destination_uid = uid,

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -672,7 +672,7 @@ size_t rdm_send_device_info_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t 
       .destination_uid = uid,
       .source_uid = rdm_get_uid(dmx_num),
       .tn = tn, 
-      .port_id = dmx_num + 1,
+      .port_id = RDM_RESPONSE_TYPE_ACK,
       .message_count = 0,
       .sub_device = 0,
       .cc = RDM_CC_GET_COMMAND_RESPONSE,

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -590,3 +590,12 @@ bool rdm_get_header(rdm_header_t* header, const void* data)
 {
     return rdm_decode_header(data, header);
 }
+
+bool rdm_is_directed_at_us(dmx_port_t dmx_num, rdm_header_t* header)
+{
+
+    return header->destination_uid == RDM_BROADCAST_ALL_UID || 
+           header->destination_uid == rdm_get_uid(dmx_num);
+
+}
+

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -586,3 +586,7 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                                   RDM_PID_IDENTIFY_DEVICE, rdm_encode_8bit,
                                   &identify, 1, NULL, NULL, 0, response);
 }
+bool rdm_get_header(rdm_header_t* header, const void* data)
+{
+    return rdm_decode_header(data, header);
+}

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -130,6 +130,13 @@ bool rdm_is_directed_at_us(dmx_port_t dmx_num, rdm_header_t* header);
 bool rdm_is_muted(dmx_port_t dmx_num);
 
 /**
+ * @brief (Un)mutes RDM discovery responses.
+ * @return true if value was set
+ * @return false if an error occured
+ */
+bool rdm_set_muted(dmx_port_t dmx_num, bool muted);
+
+/**
  * @brief Sends an RDM discovery response on the desired DMX port.
  *
  * @param dmx_num The DMX port number.

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -325,6 +325,17 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                              rdm_sub_device_t sub_device,
                              rdm_response_t *response, bool identify);
 
+
+/**
+ * @brief Sends response for the RDM_PID_DISC_MUTE request.
+ * @param dmx_num The DMX port number.
+ * @param uid The UID to which to address the response.
+ * @param tn The transaction number of the request that is beeing answered.
+ * @return the number of bytes that was sent.
+*/
+size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -103,6 +103,11 @@ rdm_uid_t rdm_get_uid(dmx_port_t dmx_num);
 void rdm_set_uid(dmx_port_t dmx_num, rdm_uid_t uid);
 
 /**
+ * @brief Extracts the rdm header from an rdm message
+ * @param header Will contain the header if @p data is valid
+ * @return true if the data contained a valid rdm header.
+*/
+bool rdm_get_header(rdm_header_t* header, const void* data);/**
  * @brief Returns true if RDM discovery responses are be muted on this device.
  *
  * @param dmx_num The DMX port number.

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -325,16 +325,27 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
                              rdm_sub_device_t sub_device,
                              rdm_response_t *response, bool identify);
 
-
 /**
  * @brief Sends response for the RDM_PID_DISC_MUTE request.
  * @param dmx_num The DMX port number.
  * @param uid The UID to which to address the response.
  * @param tn The transaction number of the request that is beeing answered.
  * @return the number of bytes that was sent.
-*/
+ */
 size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_disc_mute_t *mute_params);
 
+/**
+ * @brief Sends RDM_CC_GET_COMMAND_RESPONSE with the device_info as payload
+*/
+size_t rdm_send_device_info_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_device_info_t *device_info);
+
+/**
+ * @brief Sends RDM_CC_GET_COMMAND_RESPONSE with the identify_device as payload
+*/
+size_t rdm_send_idenfiy_device_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_sub_device_t sub_device, bool identify);
+
+//TODO
+size_t rdm_send_set_command_ack_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_sub_device_t sub_device, rdm_pid_t pid);
 
 #ifdef __cplusplus
 }

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -333,7 +333,7 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
  * @param tn The transaction number of the request that is beeing answered.
  * @return the number of bytes that was sent.
 */
-size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn);
+size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_disc_mute_t *mute_params);
 
 
 #ifdef __cplusplus

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -335,9 +335,9 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, rdm_uid_t uid,
 size_t rdm_send_mute_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_disc_mute_t *mute_params);
 
 /**
- * @brief Sends RDM_CC_GET_COMMAND_RESPONSE with the device_info as payload
+ * @brief Sends RDM_CC_GET_COMMAND_RESPONSE with the specified payload
 */
-size_t rdm_send_device_info_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, const rdm_device_info_t *device_info);
+size_t rdm_send_get_param_response(dmx_port_t dmx_num, rdm_uid_t uid, uint8_t tn, rdm_pid_t pid, uint16_t sub_device, const void* pd, size_t pdl);
 
 /**
  * @brief Sends RDM_CC_GET_COMMAND_RESPONSE with the identify_device as payload

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -107,7 +107,20 @@ void rdm_set_uid(dmx_port_t dmx_num, rdm_uid_t uid);
  * @param header Will contain the header if @p data is valid
  * @return true if the data contained a valid rdm header.
 */
-bool rdm_get_header(rdm_header_t* header, const void* data);/**
+bool rdm_get_header(rdm_header_t* header, const void* data);
+
+/**
+ * @brief Check if an rdm message is directed at us
+ * @param dmx_num The DMX port number.
+ * @param data A buffer containing the rdm message
+ * @return true if the rdm message contained in @p buffer is directed at us, 
+ *         false otherwise
+ * 
+*/
+bool rdm_is_directed_at_us(dmx_port_t dmx_num, rdm_header_t* header);
+
+
+/**
  * @brief Returns true if RDM discovery responses are be muted on this device.
  *
  * @param dmx_num The DMX port number.

--- a/src/esp_rdm_client.c
+++ b/src/esp_rdm_client.c
@@ -1,0 +1,161 @@
+#include "esp_rdm_client.h"
+#include "rdm_types.h"
+#include "esp_rdm.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_dmx.h"
+
+rdm_parameters_t rdm_parameters[DMX_NUM_MAX] = {0};
+
+bool rdm_client_init(dmx_port_t dmx_num, uint16_t start_address, uint16_t footprint)
+{
+    if (dmx_num >= DMX_NUM_MAX)
+    {
+        ESP_LOGE("rdm_client", "dmx_num too large");
+        return false;
+    }
+
+    rdm_parameters_t *params = &rdm_parameters[dmx_num];
+
+    params->device_info.major_rdm_version = 1;
+    params->device_info.minor_rdm_version = 0;
+    params->device_info.model_id = 0x4242;
+    params->device_info.coarse_product_category = 0x01; // TODO create constants for product category and fine category
+    params->device_info.fine_product_category = 0x00;
+    params->device_info.software_version_id = 0x42;
+    params->device_info.footprint = footprint;
+    params->device_info.current_personality = 1;
+    params->device_info.personality_count = 1;
+    params->device_info.start_address = start_address;
+    params->device_info.sub_device_count = 0;
+    params->device_info.sensor_count = 0;
+    params->identify_device = false;
+
+    return true;
+}
+
+
+void rdm_client_handle_discovery_command(dmx_port_t dmx_num, const rdm_header_t *header, const void *data, const uint16_t data_size)
+{
+    if (header->pid == RDM_PID_DISC_UNIQUE_BRANCH)
+    {
+        // TODO ensure that data_size is large enough
+        const rdm_uid_t lowUid = buf_to_uid(data + 24);
+        const rdm_uid_t highUid = buf_to_uid(data + 30);
+        const rdm_uid_t ourUid = rdm_get_uid(dmx_num);
+
+        if (!rdm_is_muted(dmx_num) && lowUid <= ourUid && ourUid <= highUid)
+        {
+            const size_t respSize = rdm_send_disc_response(dmx_num, 7, ourUid);
+            ESP_LOGI("RDM", "Sent discovery response. %d bytes", respSize);
+        }
+    }
+    else if (header->pid == RDM_PID_DISC_UN_MUTE)
+    {
+        ESP_LOGI("RDM", "Received UNMUTE");
+        rdm_set_muted(dmx_num, false);
+        // TODO add response for unmute
+    }
+    else if (header->pid == RDM_PID_DISC_MUTE)
+    {
+        ESP_LOGI("RDM", "Received MUTE");
+        rdm_set_muted(dmx_num, true);
+
+        // TODO store muteParams in rdm_client_params
+        rdm_disc_mute_t muteParams;
+        muteParams.managed_proxy = false;
+        muteParams.sub_device = false;
+        muteParams.boot_loader = false;
+        muteParams.proxied_device = false;
+        muteParams.binding_uid = 0;
+        const size_t bytesSent = rdm_send_mute_response(dmx_num, header->source_uid, header->tn, &muteParams);
+        if (bytesSent == 0)
+        {
+            // TODO print error or something
+        }
+    }
+}
+
+void rdm_client_handle_rdm_message(dmx_port_t dmx_num, const dmx_packet_t *dmxPacket, const void *data, const uint16_t size)
+{
+    rdm_header_t header;
+    if (rdm_get_header(&header, data))
+    {
+        if (rdm_is_directed_at_us(dmx_num, &header))
+        {
+            if (header.cc == RDM_CC_DISC_COMMAND)
+            {
+                rdm_client_handle_discovery_command(dmx_num, &header, data, size);
+            }
+            else if (header.cc == RDM_CC_GET_COMMAND)
+            {
+                switch (header.pid)
+                {
+                case RDM_PID_DEVICE_INFO:
+                {
+                    const size_t bytesSent = rdm_send_device_info_response(dmx_num, header.source_uid, header.tn, &rdm_parameters[dmx_num].device_info);
+                    ESP_LOGI("RDM DBG", "Sent DEVICE_INFO response. %d bytes", bytesSent);
+                }
+                break;
+                case RDM_PID_IDENTIFY_DEVICE:
+                {
+                    const rdm_parameters_t *params = &rdm_parameters[dmx_num];
+                    const size_t bytesSent = rdm_send_idenfiy_device_response(dmx_num, header.source_uid, header.tn, header.sub_device, params->identify_device);
+                    ESP_LOGI("RDM DBG", "Sent IDENTIFY_DEVICE response. %d bytes", bytesSent);
+                }
+                break;
+                default:
+                    ESP_LOGI("RDM DBG", " get pid: %04x", header.pid);
+                }
+            }
+            else if (header.cc == RDM_CC_SET_COMMAND)
+            {
+                switch (header.pid)
+                {
+                case RDM_PID_IDENTIFY_DEVICE:
+                {
+                    // TODO notify someone that identify changed!
+                    rdm_parameters[dmx_num].identify_device = ((uint8_t *)data)[24];
+                    const size_t bytesSent = rdm_send_set_command_ack_response(dmx_num, header.source_uid, header.tn, header.sub_device, RDM_PID_IDENTIFY_DEVICE);
+                    ESP_LOGI("RDM DBG", "Sent SET IDENTIFY_DEVICE response. %d bytes", bytesSent);
+                    ESP_LOGI("RDM DBG", "Set identify: %d", rdm_parameters[dmx_num].identify_device);
+                }
+                break;
+                default:
+                    ESP_LOGI("RDM DBG", " RDM_CC_SET_COMMAND get pid: %04x", header.pid);
+                }
+            }
+            else
+            {
+                // debugPrintRdm(header);
+            }
+        }
+    }
+}
+
+void rdm_client_set_device_info(dmx_port_t dmx_num, const rdm_device_info_t *info)
+{
+    //   if(dmx_num >= DMX_NUM_MAX)
+    //   {
+    //     ESP_LOGE("rdm_client", "dmx_num too large");
+    //     return;
+    //   }
+
+    //   rdm_parameters[dmx_num] = *info;
+}
+
+// void debugPrintRdm(const rdm_header_t header)
+// {
+//     switch (header.cc)
+//     {
+//     case RDM_CC_GET_COMMAND:
+//         ESP_LOGI("RDM DBG", " command class: GET_COMMAND");
+//         break;
+//     case RDM_CC_SET_COMMAND:
+//         ESP_LOGI("RDM DBG", " command class: SET_COMMAND");
+//         break;
+//     default:
+//         ESP_LOGI("RDM DBG", " command class: UNKNOWN %02x", header.cc);
+//     }
+//     ESP_LOGI("RDM DBG", " pid: %04x", header.pid);
+// }

--- a/src/esp_rdm_client.c
+++ b/src/esp_rdm_client.c
@@ -133,7 +133,7 @@ void rdm_client_handle_rdm_message(dmx_port_t dmx_num, const dmx_packet_t *dmxPa
                 }
                 break;
                 default:
-                    ESP_LOGI("RDM DBG", " get pid: %04x", header.pid);
+                    ESP_LOGI("RDM DBG", "unknown get pid: %04x", header.pid);
                 }
             }
             else if (header.cc == RDM_CC_SET_COMMAND)
@@ -143,10 +143,22 @@ void rdm_client_handle_rdm_message(dmx_port_t dmx_num, const dmx_packet_t *dmxPa
                 case RDM_PID_IDENTIFY_DEVICE:
                 {
                     // TODO notify someone that identify changed!
-                    rdm_parameters[dmx_num].identify_device = ((uint8_t *)data)[24];
+                    rdm_parameters[dmx_num].identify_device = ((uint8_t *)data)[24]; // FIXME find better way to get the address
                     const size_t bytesSent = rdm_send_set_command_ack_response(dmx_num, header.source_uid, header.tn, header.sub_device, RDM_PID_IDENTIFY_DEVICE);
                     ESP_LOGI("RDM DBG", "Sent SET IDENTIFY_DEVICE response. %d bytes", bytesSent);
                     ESP_LOGI("RDM DBG", "Set identify: %d", rdm_parameters[dmx_num].identify_device);
+                }
+                break;
+                case RDM_PID_DMX_START_ADDRESS:
+                {
+                    rdm_parameters_t *params = &rdm_parameters[dmx_num];
+                    uint16_t addr;
+                    memcpy(&addr, data + 24, 2);  // FIXME find better way to get the address
+                    params->device_info.start_address = bswap16(addr);
+                    const size_t bytesSent = rdm_send_set_command_ack_response(dmx_num, header.source_uid, header.tn, header.sub_device, RDM_PID_DMX_START_ADDRESS);
+                    ESP_LOGI("RDM DBG", "Sent SET DMX_START_ADDRESS response. %d bytes", bytesSent);
+                    ESP_LOGI("RDM DBG", "Start Address set to %d", params->device_info.start_address);
+                    ESP_LOG_BUFFER_HEX("RDM", data, size);
                 }
                 break;
                 default:

--- a/src/esp_rdm_client.h
+++ b/src/esp_rdm_client.h
@@ -4,7 +4,7 @@
 #include "dmx_types.h"
 
 //TODO comment
-bool rdm_client_init(dmx_port_t dmx_num, uint16_t start_address, uint16_t footprint);
+bool rdm_client_init(dmx_port_t dmx_num, uint16_t start_address, uint16_t footprint, const char* device_label);
 
 //TODO
 void rdm_client_handle_rdm_message(dmx_port_t dmx_num, const dmx_packet_t *dmxPacket, const void *data, const uint16_t size);

--- a/src/esp_rdm_client.h
+++ b/src/esp_rdm_client.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdbool.h>
+#include "rdm_types.h"
+#include "dmx_types.h"
+
+//TODO comment
+bool rdm_client_init(dmx_port_t dmx_num, uint16_t start_address, uint16_t footprint);
+
+//TODO
+void rdm_client_handle_rdm_message(dmx_port_t dmx_num, const dmx_packet_t *dmxPacket, const void *data, const uint16_t size);

--- a/src/private/rdm_encode/functions.c
+++ b/src/private/rdm_encode/functions.c
@@ -1,0 +1,438 @@
+#include "functions.h"
+#include <string.h>
+
+/**
+ * @brief Encodes a DISC_UNIQUE_BRANCH response in the desired data buffer.
+ *
+ * @param[out] data The buffer in which to encode the response.
+ * @param preamble_len The length of the response preamble (max: 7).
+ * @param uid The RDM UID to encode into the response.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_disc_response(uint8_t *data, size_t preamble_len,
+                                const rdm_uid_t uid) {
+  // Encode the RDM preamble and delimiter
+  if (preamble_len > 7) {
+    preamble_len = 7;  // Max preamble_len is 7
+  }
+  for (int i = 0; i < preamble_len; ++i) {
+    data[i] = RDM_PREAMBLE;
+  }
+  data[7] = RDM_DELIMITER;
+
+  // Encode the UID and calculate the checksum
+  uint16_t checksum = 0;
+  for (int i = 8, j = 5; i < 20; i += 2, --j) {
+    data[i] = ((uint8_t *)&uid)[j] | 0xaa;
+    data[i + 1] = ((uint8_t *)&uid)[j] | 0x55;
+    checksum += ((uint8_t *)&uid)[j] + (0xaa + 0x55);
+  }
+
+  // Encode the checksum
+  data[20] = (checksum >> 8) | 0xaa;
+  data[21] = (checksum >> 8) | 0x55;
+  data[22] = checksum | 0xaa;
+  data[23] = checksum | 0x55;
+
+  return preamble_len + 17;
+}
+
+/**
+ * @brief Decodes a DISC_UNIQUE_BRANCH response.
+ *
+ * @param[in] data The buffer in which the data to decode is stored.
+ * @param[out] uid The decoded UID in the response.
+ * @return true if the data checksum was a valid.
+ * @return false if the data checksum was invalid.
+ */
+bool rdm_decode_disc_response(const uint8_t *data, rdm_uid_t *uid) {
+  // Find the length of the discovery response preamble (0-7 bytes)
+  int preamble_len = 0;
+  for (; preamble_len < 7; ++preamble_len) {
+    if (data[preamble_len] == RDM_DELIMITER) {
+      break;
+    }
+  }
+  if (data[preamble_len] != RDM_DELIMITER) {
+    return false;  // Not a valid discovery response
+  }
+
+  // Decode the 6-byte UID and get the packet sum
+  uint16_t sum = 0;
+  data = &((uint8_t *)data)[preamble_len + 1];
+  for (int i = 5, j = 0; i >= 0; --i, j += 2) {
+    ((uint8_t *)uid)[i] = data[j] & 0x55;
+    ((uint8_t *)uid)[i] |= data[j + 1] & 0xaa;
+    sum += ((uint8_t *)uid)[i] + 0xff;
+  }
+
+  // Decode the checksum received in the response
+  uint16_t checksum;
+  for (int i = 1, j = 12; i >= 0; --i, j += 2) {
+    ((uint8_t *)&checksum)[i] = data[j] & 0x55;
+    ((uint8_t *)&checksum)[i] |= data[j + 1] & 0xaa;
+  }
+
+  return (sum == checksum);
+}
+
+/**
+ * @brief Encodes an RDM header and checksum into the desired buffer. When
+ * encoding data, parameter data must be encoded before calling this function.
+ * Otherwise, the encoded checksum will be invalid.
+ *
+ * @param[out] data The buffer in which to encode the header.
+ * @param[in] header A pointer to an RDM header used to encode data.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_header(void *data, const rdm_header_t *header) {
+  rdm_data_t *const rdm = data;
+  rdm->sc = RDM_SC;
+  rdm->sub_sc = RDM_SUB_SC;
+  rdm->message_len = header->pdl + RDM_BASE_PACKET_SIZE - 2;
+  uid_to_buf(rdm->destination_uid, header->destination_uid);
+  uid_to_buf(rdm->source_uid, header->source_uid);
+  rdm->tn = header->tn;
+  rdm->port_id = header->port_id;
+  rdm->message_count = header->message_count;
+  rdm->sub_device = bswap16(header->sub_device);
+  rdm->cc = header->cc;
+  rdm->pid = bswap16(header->pid);
+  rdm->pdl = header->pdl;
+
+  // Calculate checksum
+  uint16_t checksum = 0;
+  for (int i = 0; i < rdm->message_len; ++i) {
+    checksum += ((uint8_t *)data)[i];
+  }
+  *(uint16_t *)(data + rdm->message_len) = bswap16(checksum);
+
+  return RDM_BASE_PACKET_SIZE;
+}
+
+/**
+ * @brief Decodes an RDM header.
+ *
+ * @param[in] data The buffer in which the data to decode is stored.
+ * @param[out] header A pointer to an RDM header used to store decoded data.
+ * @return true if the data was a valid RDM packet.
+ * @return false if the data was invalid.
+ */
+bool rdm_decode_header(const void *data, rdm_header_t *header) {
+  const rdm_data_t *const rdm = data;
+  header->destination_uid = buf_to_uid(rdm->destination_uid);
+  header->source_uid = buf_to_uid(rdm->source_uid);
+  header->tn = rdm->tn;
+  header->port_id = rdm->port_id;
+  header->message_count = rdm->message_count;
+  header->sub_device = bswap16(rdm->sub_device);
+  header->cc = rdm->cc;
+  header->pid = bswap16(rdm->pid);
+  header->pdl = rdm->pdl;
+
+  // Calculate checksum
+  uint16_t sum = 0;
+  const uint16_t checksum = bswap16(*(uint16_t *)(data + rdm->message_len));
+  for (int i = 0; i < rdm->message_len; ++i) {
+    sum += *(uint8_t *)(data + i);
+  }
+  header->checksum_is_valid = (sum == checksum);
+
+  return (rdm->sc == RDM_SC && rdm->sub_sc == RDM_SUB_SC);
+}
+
+/**
+ * @brief Encodes RDM UIDs into the desired buffer.
+ *
+ * @param[out] data The buffer in which to encode the data.
+ * @param[in] uids A pointer to an array of UIDs to encode.
+ * @param size The size of the array of UIDs.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_uids(void *data, const rdm_uid_t *uids, size_t size) {
+  size_t pdl = 0;
+  for (int i = 0; i < size; ++i, pdl += 6) {
+    uid_to_buf(data + pdl, uids[i]);
+  }
+  return pdl;
+}
+
+/**
+ * @brief Decodes RDM UIDs into the desired array.
+ *
+ * @param[in] data The buffer in which the data to decode is stored.
+ * @param[out] uids A pointer to an array of UIDs to store decoded data.
+ * @param size The size of the array of UIDs.
+ * @param pdl The length of the parameter data.
+ * @return The number of UIDs decoded.
+ */
+size_t rdm_decode_uids(const void *data, rdm_uid_t *const uids, size_t size,
+                       size_t pdl) {
+  size_t num_params = 0;
+  for (int i = 0; num_params < size; ++num_params, i += 6) {
+    uids[num_params] = buf_to_uid(data + i);
+  }
+  return num_params;
+}
+
+/**
+ * @brief Encodes RDM discovery mute parameters into the desired buffer.
+ *
+ * @param[out] data The buffer in which to encode the data.
+ * @param[in] param A pointer to a discovery mute parameter to encode.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_mute(void *data, const rdm_disc_mute_t *param) {
+  size_t pdl = 2;
+  struct rdm_disc_mute_data_t *const ptr = data;
+  ptr->managed_proxy = param->managed_proxy;
+  ptr->sub_device = param->sub_device;
+  ptr->boot_loader = param->boot_loader;
+  ptr->proxied_device = param->proxied_device;
+  if (param->binding_uid) {
+    uid_to_buf(ptr->binding_uid, param->binding_uid);
+    pdl += 6;
+  }
+  return pdl;
+}
+
+/**
+ * @brief Decodes RDM discovery mute parameters.
+ *
+ * @param[in] data The buffer in which the data to decode is stored.
+ * @param[out] param A pointer to a discovery mute parameter to store decoded
+ * data.
+ * @param pdl The length of the parameter data.
+ * @return The number of parameters decoded (always 1).
+ */
+size_t rdm_decode_mute(const void *data, rdm_disc_mute_t *param, size_t size,
+                       size_t pdl) {
+  const struct rdm_disc_mute_data_t *const ptr = data;
+  param->managed_proxy = ptr->managed_proxy;
+  param->sub_device = ptr->sub_device;
+  param->boot_loader = ptr->boot_loader;
+  param->proxied_device = ptr->proxied_device;
+  param->binding_uid = pdl > 2 ? buf_to_uid(ptr->binding_uid) : 0;
+  return 1;
+}
+
+/**
+ * @brief Encode an array of 16-bit numbers into the desired array.
+ *
+ * @param[out] pd The buffer in which to encode the data.
+ * @param[in] data A pointer to an array of values to encode.
+ * @param size The size of the array of values.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_16bit(void *pd, const void *data, size_t size) {
+  if (size > RDM_PACKET_MAX_PARAMS(uint16_t)) {
+    // Don't encode more data than can fit in a single packet
+    size = RDM_PACKET_MAX_PARAMS(uint16_t);
+  }
+  size_t pdl = 0;
+  if (data != NULL) {
+    uint16_t *const restrict ptr = pd;
+    const uint32_t *const restrict params = data;
+    for (int i = 0; i < size; ++i) {
+      ptr[i] = bswap16(params[i]);
+    }
+    pdl = size * sizeof(uint16_t);
+  }
+  return pdl;
+}
+
+/**
+ * @brief Decode an array of 16-bit numbers into the desired array.
+ *
+ * @param[in] pd A pointer to the parameter data to decode.
+ * @param[out] data A pointer to an array in which to store the decoded data.
+ * @param size The size of the array to store decoded data.
+ * @param pdl The length of the parameter data.
+ * @return The number of of values available to decode.
+ */
+size_t rdm_decode_16bit(const void *pd, void *data, size_t size, size_t pdl) {
+  if (size > RDM_PDL_MAX_PARAMS(pdl, uint16_t)) {
+    // Don't decode more data than can fit in a single packet
+    size = RDM_PDL_MAX_PARAMS(pdl, uint16_t);
+  }
+  if (data != NULL) {
+    const uint16_t *const restrict ptr = pd;
+    uint32_t *restrict params = data;
+    for (int i = 0; i < size; ++i) {
+      params[i] = bswap16(ptr[i]);
+    }
+  }
+  return pdl / sizeof(uint16_t);
+}
+
+/**
+ * @brief Encode an array of 8-bit numbers into the desired array.
+ *
+ * @param[out] pd The buffer in which to encode the data.
+ * @param[in] data A pointer to an array of values to encode.
+ * @param size The size of the array of values.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_8bit(void *pd, const void *data, size_t size) {
+  if (size > RDM_PACKET_MAX_PARAMS(uint8_t)) {
+    // Don't encode more data than can fit in a single packet
+    size = RDM_PACKET_MAX_PARAMS(uint8_t);
+  }
+  size_t pdl = 0;
+  if (data != NULL) {
+    uint8_t *restrict ptr = pd;
+    const uint32_t *restrict params = data;
+    for (int i = 0; i < size; ++i) {
+      ptr[i] = params[i];
+    }
+    pdl = size;
+  }
+  return pdl;
+}
+
+/**
+ * @brief Decode an array of 8-bit numbers into the desired array.
+ *
+ * @param[in] pd A buffer in which the data to decode is stored.
+ * @param[out] data A pointer to an array in which to store the decoded data.
+ * @param size The size of the array to store decoded data.
+ * @param pdl The length of the parameter data.
+ * @return The number of of values available to be decoded.
+ */
+size_t rdm_decode_8bit(const void *pd, void *data, size_t size,
+                       size_t pdl) {
+  if (size > RDM_PDL_MAX_PARAMS(pdl, uint8_t)) {
+    size = RDM_PDL_MAX_PARAMS(pdl, uint8_t);
+  }
+  if (data != NULL) {
+    const uint8_t *restrict ptr = pd;
+    uint32_t *restrict params = data;
+    for (int i = 0; i < size; ++i) {
+      params[i] = ptr[i];
+    }
+  }
+  return pdl;
+}
+
+/**
+ * @brief Encode a string into the desired array.
+ * 
+ * @param[out] pd A buffer into which to encode the data.
+ * @param[in] data A pointer to an array of values to encode.
+ * @param size The size of the string.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_string(void *pd, const void *data, size_t size) {
+  if (size > RDM_PACKET_MAX_PARAMS(char)) {
+    size = RDM_PACKET_MAX_PARAMS(char);
+  }
+  size_t pdl = 0;
+  if (data != NULL) {
+    char *restrict destination = pd;
+    const char *restrict source = data;
+    while (pdl < size) {
+      if (*source) {
+        *destination = *source;
+        ++destination;
+        ++source;
+        ++pdl;
+      } else {
+        break;  // Don't encode null terminators
+      }
+    }
+  }
+  return pdl;
+}
+
+/**
+ * @brief Decode a string from a buffer.
+ *
+ * @param pd A buffer in which the to decode is stored.
+ * @param data A pointer into which to store the decoded data.
+ * @param size The size of the buffer to store the decoded data.
+ * @param pdl The length of the parameter data.
+ * @return The number of characters that was decoded.
+ */
+size_t rdm_decode_string(const void *pd, void *data, size_t size, size_t pdl) {
+  if (size > RDM_PDL_MAX_PARAMS(pdl, char)) {
+    size = RDM_PDL_MAX_PARAMS(pdl, char);
+  }
+  if (data != NULL) {
+    char *restrict string = data;
+    memcpy(string, pd, size);
+    string[size] = 0;
+  }
+  return pdl;
+}
+
+/**
+ * @brief Encodes RDM device info into the desired buffer.
+ *
+ * @param[out] pd The buffer in which to encode the data.
+ * @param[in] device_info A pointer to the device info data
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_device_info_(void *pd, const rdm_device_info_t *const restrict device_info) {
+  rdm_device_info_data_t *const restrict ptr = pd;
+  ptr->major_rdm_version = device_info->major_rdm_version;
+  ptr->minor_rdm_version = device_info->minor_rdm_version;
+  ptr->model_id = bswap16(device_info->model_id);
+  ptr->coarse_product_category = device_info->coarse_product_category;
+  ptr->fine_product_category = device_info->fine_product_category;
+  ptr->software_version_id = bswap32(device_info->software_version_id);
+  ptr->footprint = bswap16(device_info->footprint);
+  ptr->current_personality = device_info->current_personality;
+  ptr->personality_count = device_info->personality_count;
+  ptr->start_address = device_info->start_address != -1
+                          ? bswap16(device_info->start_address)
+                          : 0xffff;
+  ptr->sub_device_count = bswap16(device_info->sub_device_count);
+  ptr->sensor_count = device_info->sensor_count;
+  return sizeof(rdm_device_info_data_t);
+}
+
+/**
+ * @brief Encodes RDM device info into the desired buffer.
+ *
+ * @param[out] pd The buffer in which to encode the data.
+ * @param[in] data A pointer to a discovery mute parameter to encode.
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_device_info(void *pd, const void *data) {
+  if (data != NULL) {
+    const rdm_device_info_t *const restrict device_info = data;
+    return rdm_encode_device_info(pd, device_info);
+  }
+  return sizeof(rdm_device_info_data_t);
+}
+
+/**
+ * @brief Decodes RDM device info.
+ *
+ * @param[in] pd The buffer in which the data to decode is stored.
+ * @param[out] data A pointer to a device info parameter to store decoded data.
+ * @param size The size of the array to store decoded data.
+ * @param pdl The length of the parameter data.
+ * @return The number of parameters decoded (always 1).
+ */
+size_t rdm_decode_device_info(const void *pd, void *data, size_t size,
+                              size_t pdl) {
+  if (data != NULL) {
+    const rdm_device_info_data_t *restrict ptr = pd;
+    rdm_device_info_t *const restrict device_info = data;
+    device_info->major_rdm_version = ptr->major_rdm_version;
+    device_info->minor_rdm_version = ptr->minor_rdm_version;
+    device_info->model_id = bswap16(ptr->model_id);
+    device_info->coarse_product_category = ptr->coarse_product_category;
+    device_info->fine_product_category = ptr->fine_product_category;
+    device_info->software_version_id = bswap32(ptr->software_version_id);
+    device_info->footprint = bswap16(ptr->footprint);
+    device_info->current_personality = ptr->current_personality;
+    device_info->personality_count = ptr->personality_count;
+    device_info->start_address =
+        ptr->start_address != 0xffff ? bswap16(ptr->start_address) : -1;
+    device_info->sub_device_count = bswap16(ptr->sub_device_count);
+    device_info->sensor_count = ptr->sensor_count;
+  }
+  return 1;
+}

--- a/src/private/rdm_encode/functions.h
+++ b/src/private/rdm_encode/functions.h
@@ -24,32 +24,7 @@ extern "C" {
  * @return The number of bytes encoded.
  */
 size_t rdm_encode_disc_response(uint8_t *data, size_t preamble_len,
-                                const rdm_uid_t uid) {
-  // Encode the RDM preamble and delimiter
-  if (preamble_len > 7) {
-    preamble_len = 7;  // Max preamble_len is 7
-  }
-  for (int i = 0; i < preamble_len; ++i) {
-    data[i] = RDM_PREAMBLE;
-  }
-  data[7] = RDM_DELIMITER;
-
-  // Encode the UID and calculate the checksum
-  uint16_t checksum = 0;
-  for (int i = 8, j = 5; i < 20; i += 2, --j) {
-    data[i] = ((uint8_t *)&uid)[j] | 0xaa;
-    data[i + 1] = ((uint8_t *)&uid)[j] | 0x55;
-    checksum += ((uint8_t *)&uid)[j] + (0xaa + 0x55);
-  }
-
-  // Encode the checksum
-  data[20] = (checksum >> 8) | 0xaa;
-  data[21] = (checksum >> 8) | 0x55;
-  data[22] = checksum | 0xaa;
-  data[23] = checksum | 0x55;
-
-  return preamble_len + 17;
-}
+                                const rdm_uid_t uid);
 
 /**
  * @brief Decodes a DISC_UNIQUE_BRANCH response.
@@ -59,36 +34,7 @@ size_t rdm_encode_disc_response(uint8_t *data, size_t preamble_len,
  * @return true if the data checksum was a valid.
  * @return false if the data checksum was invalid.
  */
-bool rdm_decode_disc_response(const uint8_t *data, rdm_uid_t *uid) {
-  // Find the length of the discovery response preamble (0-7 bytes)
-  int preamble_len = 0;
-  for (; preamble_len < 7; ++preamble_len) {
-    if (data[preamble_len] == RDM_DELIMITER) {
-      break;
-    }
-  }
-  if (data[preamble_len] != RDM_DELIMITER) {
-    return false;  // Not a valid discovery response
-  }
-
-  // Decode the 6-byte UID and get the packet sum
-  uint16_t sum = 0;
-  data = &((uint8_t *)data)[preamble_len + 1];
-  for (int i = 5, j = 0; i >= 0; --i, j += 2) {
-    ((uint8_t *)uid)[i] = data[j] & 0x55;
-    ((uint8_t *)uid)[i] |= data[j + 1] & 0xaa;
-    sum += ((uint8_t *)uid)[i] + 0xff;
-  }
-
-  // Decode the checksum received in the response
-  uint16_t checksum;
-  for (int i = 1, j = 12; i >= 0; --i, j += 2) {
-    ((uint8_t *)&checksum)[i] = data[j] & 0x55;
-    ((uint8_t *)&checksum)[i] |= data[j + 1] & 0xaa;
-  }
-
-  return (sum == checksum);
-}
+bool rdm_decode_disc_response(const uint8_t *data, rdm_uid_t *uid);
 
 /**
  * @brief Encodes an RDM header and checksum into the desired buffer. When
@@ -99,30 +45,7 @@ bool rdm_decode_disc_response(const uint8_t *data, rdm_uid_t *uid) {
  * @param[in] header A pointer to an RDM header used to encode data.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_header(void *data, const rdm_header_t *header) {
-  rdm_data_t *const rdm = data;
-  rdm->sc = RDM_SC;
-  rdm->sub_sc = RDM_SUB_SC;
-  rdm->message_len = header->pdl + RDM_BASE_PACKET_SIZE - 2;
-  uid_to_buf(rdm->destination_uid, header->destination_uid);
-  uid_to_buf(rdm->source_uid, header->source_uid);
-  rdm->tn = header->tn;
-  rdm->port_id = header->port_id;
-  rdm->message_count = header->message_count;
-  rdm->sub_device = bswap16(header->sub_device);
-  rdm->cc = header->cc;
-  rdm->pid = bswap16(header->pid);
-  rdm->pdl = header->pdl;
-
-  // Calculate checksum
-  uint16_t checksum = 0;
-  for (int i = 0; i < rdm->message_len; ++i) {
-    checksum += ((uint8_t *)data)[i];
-  }
-  *(uint16_t *)(data + rdm->message_len) = bswap16(checksum);
-
-  return RDM_BASE_PACKET_SIZE;
-}
+size_t rdm_encode_header(void *data, const rdm_header_t *header);
 
 /**
  * @brief Decodes an RDM header.
@@ -132,29 +55,7 @@ size_t rdm_encode_header(void *data, const rdm_header_t *header) {
  * @return true if the data was a valid RDM packet.
  * @return false if the data was invalid.
  */
-bool rdm_decode_header(const void *data, rdm_header_t *header) {
-  const rdm_data_t *const rdm = data;
-  header->destination_uid = buf_to_uid(rdm->destination_uid);
-  header->source_uid = buf_to_uid(rdm->source_uid);
-  header->tn = rdm->tn;
-  header->port_id = rdm->port_id;
-  header->message_count = rdm->message_count;
-  header->sub_device = bswap16(rdm->sub_device);
-  header->cc = rdm->cc;
-  header->pid = bswap16(rdm->pid);
-  header->pdl = rdm->pdl;
-
-  // Calculate checksum
-  uint16_t sum = 0;
-  const uint16_t checksum = bswap16(*(uint16_t *)(data + rdm->message_len));
-  for (int i = 0; i < rdm->message_len; ++i) {
-    sum += *(uint8_t *)(data + i);
-  }
-  header->checksum_is_valid = (sum == checksum);
-
-  return (rdm->sc == RDM_SC && rdm->sub_sc == RDM_SUB_SC);
-}
-
+bool rdm_decode_header(const void *data, rdm_header_t *header);
 /**
  * @brief Encodes RDM UIDs into the desired buffer.
  *
@@ -163,13 +64,7 @@ bool rdm_decode_header(const void *data, rdm_header_t *header) {
  * @param size The size of the array of UIDs.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_uids(void *data, const rdm_uid_t *uids, size_t size) {
-  size_t pdl = 0;
-  for (int i = 0; i < size; ++i, pdl += 6) {
-    uid_to_buf(data + pdl, uids[i]);
-  }
-  return pdl;
-}
+size_t rdm_encode_uids(void *data, const rdm_uid_t *uids, size_t size);
 
 /**
  * @brief Decodes RDM UIDs into the desired array.
@@ -181,13 +76,7 @@ size_t rdm_encode_uids(void *data, const rdm_uid_t *uids, size_t size) {
  * @return The number of UIDs decoded.
  */
 size_t rdm_decode_uids(const void *data, rdm_uid_t *const uids, size_t size,
-                       size_t pdl) {
-  size_t num_params = 0;
-  for (int i = 0; num_params < size; ++num_params, i += 6) {
-    uids[num_params] = buf_to_uid(data + i);
-  }
-  return num_params;
-}
+                       size_t pdl);
 
 /**
  * @brief Encodes RDM discovery mute parameters into the desired buffer.
@@ -196,19 +85,7 @@ size_t rdm_decode_uids(const void *data, rdm_uid_t *const uids, size_t size,
  * @param[in] param A pointer to a discovery mute parameter to encode.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_mute(void *data, const rdm_disc_mute_t *param) {
-  size_t pdl = 2;
-  struct rdm_disc_mute_data_t *const ptr = data;
-  ptr->managed_proxy = param->managed_proxy;
-  ptr->sub_device = param->sub_device;
-  ptr->boot_loader = param->boot_loader;
-  ptr->proxied_device = param->proxied_device;
-  if (param->binding_uid) {
-    uid_to_buf(ptr->binding_uid, param->binding_uid);
-    pdl += 6;
-  }
-  return pdl;
-}
+size_t rdm_encode_mute(void *data, const rdm_disc_mute_t *param);
 
 /**
  * @brief Decodes RDM discovery mute parameters.
@@ -220,16 +97,7 @@ size_t rdm_encode_mute(void *data, const rdm_disc_mute_t *param) {
  * @return The number of parameters decoded (always 1).
  */
 size_t rdm_decode_mute(const void *data, rdm_disc_mute_t *param, size_t size,
-                       size_t pdl) {
-  const struct rdm_disc_mute_data_t *const ptr = data;
-  param->managed_proxy = ptr->managed_proxy;
-  param->sub_device = ptr->sub_device;
-  param->boot_loader = ptr->boot_loader;
-  param->proxied_device = ptr->proxied_device;
-  param->binding_uid = pdl > 2 ? buf_to_uid(ptr->binding_uid) : 0;
-  return 1;
-}
-
+                       size_t pdl);
 /**
  * @brief Encode an array of 16-bit numbers into the desired array.
  *
@@ -238,22 +106,7 @@ size_t rdm_decode_mute(const void *data, rdm_disc_mute_t *param, size_t size,
  * @param size The size of the array of values.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_16bit(void *pd, const void *data, size_t size) {
-  if (size > RDM_PACKET_MAX_PARAMS(uint16_t)) {
-    // Don't encode more data than can fit in a single packet
-    size = RDM_PACKET_MAX_PARAMS(uint16_t);
-  }
-  size_t pdl = 0;
-  if (data != NULL) {
-    uint16_t *const restrict ptr = pd;
-    const uint32_t *const restrict params = data;
-    for (int i = 0; i < size; ++i) {
-      ptr[i] = bswap16(params[i]);
-    }
-    pdl = size * sizeof(uint16_t);
-  }
-  return pdl;
-}
+size_t rdm_encode_16bit(void *pd, const void *data, size_t size);
 
 /**
  * @brief Decode an array of 16-bit numbers into the desired array.
@@ -264,21 +117,7 @@ size_t rdm_encode_16bit(void *pd, const void *data, size_t size) {
  * @param pdl The length of the parameter data.
  * @return The number of of values available to decode.
  */
-size_t rdm_decode_16bit(const void *pd, void *data, size_t size, size_t pdl) {
-  if (size > RDM_PDL_MAX_PARAMS(pdl, uint16_t)) {
-    // Don't decode more data than can fit in a single packet
-    size = RDM_PDL_MAX_PARAMS(pdl, uint16_t);
-  }
-  if (data != NULL) {
-    const uint16_t *const restrict ptr = pd;
-    uint32_t *restrict params = data;
-    for (int i = 0; i < size; ++i) {
-      params[i] = bswap16(ptr[i]);
-    }
-  }
-  return pdl / sizeof(uint16_t);
-}
-
+size_t rdm_decode_16bit(const void *pd, void *data, size_t size, size_t pdl);
 /**
  * @brief Encode an array of 8-bit numbers into the desired array.
  *
@@ -287,23 +126,7 @@ size_t rdm_decode_16bit(const void *pd, void *data, size_t size, size_t pdl) {
  * @param size The size of the array of values.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_8bit(void *pd, const void *data, size_t size) {
-  if (size > RDM_PACKET_MAX_PARAMS(uint8_t)) {
-    // Don't encode more data than can fit in a single packet
-    size = RDM_PACKET_MAX_PARAMS(uint8_t);
-  }
-  size_t pdl = 0;
-  if (data != NULL) {
-    uint8_t *restrict ptr = pd;
-    const uint32_t *restrict params = data;
-    for (int i = 0; i < size; ++i) {
-      ptr[i] = params[i];
-    }
-    pdl = size;
-  }
-  return pdl;
-}
-
+size_t rdm_encode_8bit(void *pd, const void *data, size_t size);
 /**
  * @brief Decode an array of 8-bit numbers into the desired array.
  *
@@ -314,20 +137,7 @@ size_t rdm_encode_8bit(void *pd, const void *data, size_t size) {
  * @return The number of of values available to be decoded.
  */
 size_t rdm_decode_8bit(const void *pd, void *data, size_t size,
-                       size_t pdl) {
-  if (size > RDM_PDL_MAX_PARAMS(pdl, uint8_t)) {
-    size = RDM_PDL_MAX_PARAMS(pdl, uint8_t);
-  }
-  if (data != NULL) {
-    const uint8_t *restrict ptr = pd;
-    uint32_t *restrict params = data;
-    for (int i = 0; i < size; ++i) {
-      params[i] = ptr[i];
-    }
-  }
-  return pdl;
-}
-
+                       size_t pdl);
 /**
  * @brief Encode a string into the desired array.
  * 
@@ -336,27 +146,7 @@ size_t rdm_decode_8bit(const void *pd, void *data, size_t size,
  * @param size The size of the string.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_string(void *pd, const void *data, size_t size) {
-  if (size > RDM_PACKET_MAX_PARAMS(char)) {
-    size = RDM_PACKET_MAX_PARAMS(char);
-  }
-  size_t pdl = 0;
-  if (data != NULL) {
-    char *restrict destination = pd;
-    const char *restrict source = data;
-    while (pdl < size) {
-      if (*source) {
-        *destination = *source;
-        ++destination;
-        ++source;
-        ++pdl;
-      } else {
-        break;  // Don't encode null terminators
-      }
-    }
-  }
-  return pdl;
-}
+size_t rdm_encode_string(void *pd, const void *data, size_t size);
 
 /**
  * @brief Decode a string from a buffer.
@@ -367,17 +157,7 @@ size_t rdm_encode_string(void *pd, const void *data, size_t size) {
  * @param pdl The length of the parameter data.
  * @return The number of characters that was decoded.
  */
-size_t rdm_decode_string(const void *pd, void *data, size_t size, size_t pdl) {
-  if (size > RDM_PDL_MAX_PARAMS(pdl, char)) {
-    size = RDM_PDL_MAX_PARAMS(pdl, char);
-  }
-  if (data != NULL) {
-    char *restrict string = data;
-    memcpy(string, pd, size);
-    string[size] = 0;
-  }
-  return pdl;
-}
+size_t rdm_decode_string(const void *pd, void *data, size_t size, size_t pdl);
 
 /**
  * @brief Encodes RDM device info into the desired buffer.
@@ -386,24 +166,7 @@ size_t rdm_decode_string(const void *pd, void *data, size_t size, size_t pdl) {
  * @param[in] device_info A pointer to the device info data
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_device_info_(void *pd, const rdm_device_info_t *const restrict device_info) {
-  rdm_device_info_data_t *const restrict ptr = pd;
-  ptr->major_rdm_version = device_info->major_rdm_version;
-  ptr->minor_rdm_version = device_info->minor_rdm_version;
-  ptr->model_id = bswap16(device_info->model_id);
-  ptr->coarse_product_category = device_info->coarse_product_category;
-  ptr->fine_product_category = device_info->fine_product_category;
-  ptr->software_version_id = bswap32(device_info->software_version_id);
-  ptr->footprint = bswap16(device_info->footprint);
-  ptr->current_personality = device_info->current_personality;
-  ptr->personality_count = device_info->personality_count;
-  ptr->start_address = device_info->start_address != -1
-                          ? bswap16(device_info->start_address)
-                          : 0xffff;
-  ptr->sub_device_count = bswap16(device_info->sub_device_count);
-  ptr->sensor_count = device_info->sensor_count;
-  return sizeof(rdm_device_info_data_t);
-}
+size_t rdm_encode_device_info_(void *pd, const rdm_device_info_t *const restrict device_info);
 
 /**
  * @brief Encodes RDM device info into the desired buffer.
@@ -412,14 +175,7 @@ size_t rdm_encode_device_info_(void *pd, const rdm_device_info_t *const restrict
  * @param[in] data A pointer to a discovery mute parameter to encode.
  * @return The number of bytes encoded.
  */
-size_t rdm_encode_device_info(void *pd, const void *data) {
-  if (data != NULL) {
-    const rdm_device_info_t *const restrict device_info = data;
-    return rdm_encode_device_info(pd, device_info);
-  }
-  return sizeof(rdm_device_info_data_t);
-}
-
+size_t rdm_encode_device_info(void *pd, const void *data);
 /**
  * @brief Decodes RDM device info.
  *
@@ -430,26 +186,7 @@ size_t rdm_encode_device_info(void *pd, const void *data) {
  * @return The number of parameters decoded (always 1).
  */
 size_t rdm_decode_device_info(const void *pd, void *data, size_t size,
-                              size_t pdl) {
-  if (data != NULL) {
-    const rdm_device_info_data_t *restrict ptr = pd;
-    rdm_device_info_t *const restrict device_info = data;
-    device_info->major_rdm_version = ptr->major_rdm_version;
-    device_info->minor_rdm_version = ptr->minor_rdm_version;
-    device_info->model_id = bswap16(ptr->model_id);
-    device_info->coarse_product_category = ptr->coarse_product_category;
-    device_info->fine_product_category = ptr->fine_product_category;
-    device_info->software_version_id = bswap32(ptr->software_version_id);
-    device_info->footprint = bswap16(ptr->footprint);
-    device_info->current_personality = ptr->current_personality;
-    device_info->personality_count = ptr->personality_count;
-    device_info->start_address =
-        ptr->start_address != 0xffff ? bswap16(ptr->start_address) : -1;
-    device_info->sub_device_count = bswap16(ptr->sub_device_count);
-    device_info->sensor_count = ptr->sensor_count;
-  }
-  return 1;
-}
+                              size_t pdl);
 
 #ifdef __cplusplus
 }

--- a/src/private/rdm_encode/functions.h
+++ b/src/private/rdm_encode/functions.h
@@ -383,27 +383,39 @@ size_t rdm_decode_string(const void *pd, void *data, size_t size, size_t pdl) {
  * @brief Encodes RDM device info into the desired buffer.
  *
  * @param[out] pd The buffer in which to encode the data.
+ * @param[in] device_info A pointer to the device info data
+ * @return The number of bytes encoded.
+ */
+size_t rdm_encode_device_info_(void *pd, const rdm_device_info_t *const restrict device_info) {
+  rdm_device_info_data_t *const restrict ptr = pd;
+  ptr->major_rdm_version = device_info->major_rdm_version;
+  ptr->minor_rdm_version = device_info->minor_rdm_version;
+  ptr->model_id = bswap16(device_info->model_id);
+  ptr->coarse_product_category = device_info->coarse_product_category;
+  ptr->fine_product_category = device_info->fine_product_category;
+  ptr->software_version_id = bswap32(device_info->software_version_id);
+  ptr->footprint = bswap16(device_info->footprint);
+  ptr->current_personality = device_info->current_personality;
+  ptr->personality_count = device_info->personality_count;
+  ptr->start_address = device_info->start_address != -1
+                          ? bswap16(device_info->start_address)
+                          : 0xffff;
+  ptr->sub_device_count = bswap16(device_info->sub_device_count);
+  ptr->sensor_count = device_info->sensor_count;
+  return sizeof(rdm_device_info_data_t);
+}
+
+/**
+ * @brief Encodes RDM device info into the desired buffer.
+ *
+ * @param[out] pd The buffer in which to encode the data.
  * @param[in] data A pointer to a discovery mute parameter to encode.
  * @return The number of bytes encoded.
  */
 size_t rdm_encode_device_info(void *pd, const void *data) {
   if (data != NULL) {
-    rdm_device_info_data_t *const restrict ptr = pd;
     const rdm_device_info_t *const restrict device_info = data;
-    ptr->major_rdm_version = device_info->major_rdm_version;
-    ptr->minor_rdm_version = device_info->minor_rdm_version;
-    ptr->model_id = bswap16(device_info->model_id);
-    ptr->coarse_product_category = device_info->coarse_product_category;
-    ptr->fine_product_category = device_info->fine_product_category;
-    ptr->software_version_id = bswap32(device_info->software_version_id);
-    ptr->footprint = bswap16(device_info->footprint);
-    ptr->current_personality = device_info->current_personality;
-    ptr->personality_count = device_info->personality_count;
-    ptr->start_address = device_info->start_address != -1
-                            ? bswap16(device_info->start_address)
-                            : 0xffff;
-    ptr->sub_device_count = bswap16(device_info->sub_device_count);
-    ptr->sensor_count = device_info->sensor_count;
+    return rdm_encode_device_info(pd, device_info);
   }
   return sizeof(rdm_device_info_data_t);
 }

--- a/src/rdm_types.h
+++ b/src/rdm_types.h
@@ -289,7 +289,9 @@ typedef struct rdm_device_info_t {
 */
 typedef struct rdm_parameters_t {
   rdm_device_info_t device_info;
-  bool identify_device;  
+  bool identify_device;
+  char device_label[32];
+  size_t device_label_len;  
 } rdm_parameters_t;
 
 #ifdef __cplusplus

--- a/src/rdm_types.h
+++ b/src/rdm_types.h
@@ -284,6 +284,14 @@ typedef struct rdm_device_info_t {
 } rdm_device_info_t;
 
 
+/**
+ * All parameters of a rdm client device
+*/
+typedef struct rdm_parameters_t {
+  rdm_device_info_t device_info;
+  bool identify_device;  
+} rdm_parameters_t;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I added some helper functions that I need to make the device discoverable via RDM.

The example was tested using the "Botex Dr. RDM | DMX RDM Tester" and it works.

Do you think it would make sense to add basic rdm stuff like discovery, getting/setting the dmx address etc. directly to the
esp_dmx.h? Imo there is no need for the user to implement the basic stuff himself.
