### PR TITLE
ESP-IDF v5 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
   SRCS "src/esp_dmx.c" "src/esp_rdm.c" "src/private/rdm_encode/functions.c"
   INCLUDE_DIRS "src" 
+  REQUIRES driver esp_timer esp_common esp_hw_support
 )   

--- a/Kconfig
+++ b/Kconfig
@@ -1,17 +1,14 @@
-menu "DMX Configuration"
+menu "DMX/RDM Configuration"
 
     config DMX_ISR_IN_IRAM
         bool "Place DMX ISR functions in IRAM"
-        default n
+        default y
+        select GPTIMER_ISR_IRAM_SAFE
+        select GPTIMER_CTRL_FUNC_IN_IRAM
         help
             The ISR of the DMX driver can be placed in IRAM so that it can work 
             without the flash when an interrupt is triggered. If this option is
-            disabled, DMX interrupts may take extra time when accessing flash 
-            memory.
-    
-endmenu
-
-menu "RDM Configuration"
+            disabled, DMX interrupts may take extra time to fire.
 
     config RDM_DEBUG_DEVICE_DISCOVERY
         bool "Enable debugging for RDM device discovery"

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -4,8 +4,6 @@
 
 #include "dmx_types.h"
 #include "driver/gpio.h"
-#include "driver/periph_ctrl.h"
-#include "driver/timer.h"
 #include "driver/uart.h"
 #include "endian.h"
 #include "esp_check.h"
@@ -15,6 +13,15 @@
 #include "private/driver.h"
 #include "private/rdm_encode/types.h"
 #include "rdm_types.h"
+
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "driver/gptimer.h"
+#include "esp_timer.h"
+// TODO: replacement for "driver/periph_ctrl.h"
+#else
+#include "driver/timer.h"
+#include "driver/periph_ctrl.h"
+#endif
 
 #ifdef CONFIG_DMX_ISR_IN_IRAM
 #define DMX_ISR_ATTR IRAM_ATTR
@@ -134,7 +141,7 @@ static void DMX_ISR_ATTR dmx_uart_isr(void *arg) {
       dmx_uart_clear_interrupt(uart, DMX_INTR_RX_BREAK | DMX_INTR_RX_DATA);
 
       // Pause the receive timer alarm
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -180,7 +187,7 @@ static void DMX_ISR_ATTR dmx_uart_isr(void *arg) {
       dmx_uart_clear_interrupt(uart, DMX_INTR_RX_DATA);
 
       // Pause the receive timer alarm
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -359,7 +366,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
       driver->is_in_break = false;
 
       // Reset the alarm for the end of the DMX mark-after-break
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -373,7 +380,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
       driver->data.head += write_size;
 
       // Pause MAB timer alarm
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -389,7 +396,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
                        eSetValueWithOverwrite, &task_awoken);
 
     // Pause the receive timer alarm
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
     // TODO
 #else
@@ -503,7 +510,7 @@ esp_err_t dmx_driver_install(dmx_port_t dmx_num, int intr_flags) {
                  driver, &driver->uart_isr_handle);
 
   // Initialize hardware timer
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
   // TODO
 #else
@@ -565,7 +572,7 @@ esp_err_t dmx_driver_delete(dmx_port_t dmx_num) {
   }
 
   // Free hardware timer ISR
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
   // TODO
 #else
@@ -1005,7 +1012,7 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
     const int64_t elapsed = esp_timer_get_time() - driver->data.timestamp;
     if (elapsed < RDM_CONTROLLER_RESPONSE_LOST_TIMEOUT) {
       // Start a timer alarm that triggers when the RDM timeout occurs
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -1122,7 +1129,7 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
   }
   elapsed = esp_timer_get_time() - driver->data.timestamp;
   if (elapsed < timeout) {
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
     // TODO
 #else
@@ -1138,7 +1145,7 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
   if (elapsed < timeout) {
     bool notified = xTaskNotifyWait(0, ULONG_MAX, NULL, portMAX_DELAY);
     if (!notified) {
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
       // TODO
 #else
@@ -1219,7 +1226,7 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
     driver->data.head = 0;
     driver->is_in_break = true;
     driver->is_sending = true;
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
     // TODO
 #else

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -142,8 +142,7 @@ static void DMX_ISR_ATTR dmx_uart_isr(void *arg) {
 
       // Pause the receive timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      gptimer_stop(driver->gptimer_handle);
 #else
       timer_group_set_counter_enable_in_isr(driver->timer_group,
                                             driver->timer_idx, 0);
@@ -188,8 +187,7 @@ static void DMX_ISR_ATTR dmx_uart_isr(void *arg) {
 
       // Pause the receive timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      gptimer_stop(driver->gptimer_handle);
 #else
       timer_group_set_counter_enable_in_isr(driver->timer_group,
                                             driver->timer_idx, 0);
@@ -356,7 +354,12 @@ static void DMX_ISR_ATTR dmx_gpio_isr(void *arg) {
   if (task_awoken) portYIELD_FROM_ISR();
 }
 
-static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
+static bool DMX_ISR_ATTR dmx_timer_isr(
+#if ESP_IDF_VERSION_MAJOR >= 5
+    gptimer_handle_t gptimer_handle,
+    const gptimer_alarm_event_data_t *event_data,
+#endif
+    void *arg) {
   dmx_driver_t *const restrict driver = (dmx_driver_t *)arg;
   int task_awoken = false;
 
@@ -367,8 +370,10 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
 
       // Reset the alarm for the end of the DMX mark-after-break
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      const gptimer_alarm_config_t alarm_config = {
+          .alarm_count = driver->mab_len,
+          .flags.auto_reload_on_alarm = false};
+      gptimer_set_alarm_action(gptimer_handle, &alarm_config);
 #else
       timer_group_set_alarm_value_in_isr(driver->timer_group, driver->timer_idx,
                                          driver->mab_len);
@@ -381,8 +386,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
 
       // Pause MAB timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      gptimer_stop(gptimer_handle);
 #else
       timer_group_set_counter_enable_in_isr(driver->timer_group,
                                             driver->timer_idx, 0);
@@ -397,8 +401,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(void *arg) {
 
     // Pause the receive timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-    // TODO
+    gptimer_stop(gptimer_handle);
 #else
     timer_group_set_counter_enable_in_isr(driver->timer_group,
                                           driver->timer_idx, 0);
@@ -511,8 +514,15 @@ esp_err_t dmx_driver_install(dmx_port_t dmx_num, int intr_flags) {
 
   // Initialize hardware timer
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-  // TODO
+  const gptimer_config_t timer_config = {
+      .clk_src = GPTIMER_CLK_SRC_APB,
+      .direction = GPTIMER_COUNT_UP,
+      .resolution_hz = 1000000,  // 1MHz resolution timer
+  };
+  gptimer_new_timer(&timer_config, &driver->gptimer_handle);  // TODO: err check
+  const gptimer_event_callbacks_t gptimer_cb = {.on_alarm = dmx_timer_isr};
+  gptimer_register_event_callbacks(driver->gptimer_handle, &gptimer_cb, driver);
+  gptimer_enable(driver->gptimer_handle);
 #else
   driver->timer_group = dmx_num / 2;
   driver->timer_idx = dmx_num % 2;
@@ -573,8 +583,8 @@ esp_err_t dmx_driver_delete(dmx_port_t dmx_num) {
 
   // Free hardware timer ISR
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-  // TODO
+  gptimer_disable(driver->gptimer_handle);
+  gptimer_del_timer(driver->gptimer_handle);
 #else
   timer_isr_callback_remove(driver->timer_group, driver->timer_idx);
   timer_deinit(driver->timer_group, driver->timer_idx);
@@ -1013,8 +1023,12 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
     if (elapsed < RDM_CONTROLLER_RESPONSE_LOST_TIMEOUT) {
       // Start a timer alarm that triggers when the RDM timeout occurs
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      gptimer_set_raw_count(driver->gptimer_handle, elapsed);
+      const gptimer_alarm_config_t alarm_config = {
+          .alarm_count = RDM_CONTROLLER_RESPONSE_LOST_TIMEOUT,
+          .flags.auto_reload_on_alarm = false};
+      gptimer_set_alarm_action(driver->gptimer_handle, &alarm_config);
+      gptimer_start(driver->gptimer_handle);
 #else
       const timer_group_t timer_group = driver->timer_group;
       const timer_idx_t timer_idx = driver->timer_idx;
@@ -1130,8 +1144,12 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
   elapsed = esp_timer_get_time() - driver->data.timestamp;
   if (elapsed < timeout) {
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-    // TODO
+    gptimer_set_raw_count(driver->gptimer_handle, elapsed);
+    const gptimer_alarm_config_t alarm_config = {
+        .alarm_count = timeout,
+        .flags.auto_reload_on_alarm = false};
+    gptimer_set_alarm_action(driver->gptimer_handle, &alarm_config);
+    gptimer_start(driver->gptimer_handle);
 #else
     timer_set_counter_value(driver->timer_group, driver->timer_idx, elapsed);
     timer_set_alarm_value(driver->timer_group, driver->timer_idx, timeout);
@@ -1146,8 +1164,7 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
     bool notified = xTaskNotifyWait(0, ULONG_MAX, NULL, portMAX_DELAY);
     if (!notified) {
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-      // TODO
+      gptimer_stop(driver->gptimer_handle);
 #else
       timer_pause(driver->timer_group, driver->timer_idx);
 #endif
@@ -1227,8 +1244,13 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
     driver->is_in_break = true;
     driver->is_sending = true;
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-    // TODO
+    gptimer_set_raw_count(driver->gptimer_handle, 0);
+    const gptimer_alarm_config_t alarm_config = {
+        .alarm_count = driver->break_len,
+        .reload_count = 0,
+        .flags.auto_reload_on_alarm = true};
+    gptimer_set_alarm_action(driver->gptimer_handle, &alarm_config);
+    gptimer_start(driver->gptimer_handle);
 #else
     timer_set_counter_value(driver->timer_group, driver->timer_idx, 0);
     timer_set_alarm_value(driver->timer_group, driver->timer_idx,

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -16,11 +16,11 @@
 
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include "driver/gptimer.h"
+#include "esp_private/periph_ctrl.h"
 #include "esp_timer.h"
-// TODO: replacement for "driver/periph_ctrl.h"
 #else
-#include "driver/timer.h"
 #include "driver/periph_ctrl.h"
+#include "driver/timer.h"
 #endif
 
 #ifdef CONFIG_DMX_ISR_IN_IRAM

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -1144,6 +1144,7 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
   elapsed = esp_timer_get_time() - driver->data.timestamp;
   if (elapsed < timeout) {
 #if ESP_IDF_VERSION_MAJOR >= 5
+    // FIXME: The driver isn't waiting long enough after sending an RDM packet before sending a new packet
     gptimer_set_raw_count(driver->gptimer_handle, elapsed);
     const gptimer_alarm_config_t alarm_config = {
         .alarm_count = timeout,

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -387,6 +387,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(
       // Pause MAB timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
       gptimer_stop(gptimer_handle);
+      gptimer_set_raw_count(gptimer_handle, 0);
 #else
       timer_group_set_counter_enable_in_isr(driver->timer_group,
                                             driver->timer_idx, 0);
@@ -402,6 +403,7 @@ static bool DMX_ISR_ATTR dmx_timer_isr(
     // Pause the receive timer alarm
 #if ESP_IDF_VERSION_MAJOR >= 5
     gptimer_stop(gptimer_handle);
+    gptimer_set_raw_count(gptimer_handle, 0);
 #else
     timer_group_set_counter_enable_in_isr(driver->timer_group,
                                           driver->timer_idx, 0);
@@ -1144,7 +1146,6 @@ size_t dmx_send(dmx_port_t dmx_num, size_t size) {
   elapsed = esp_timer_get_time() - driver->data.timestamp;
   if (elapsed < timeout) {
 #if ESP_IDF_VERSION_MAJOR >= 5
-    // FIXME: The driver isn't waiting long enough after sending an RDM packet before sending a new packet
     gptimer_set_raw_count(driver->gptimer_handle, elapsed);
     const gptimer_alarm_config_t alarm_config = {
         .alarm_count = timeout,

--- a/src/esp_rdm.c
+++ b/src/esp_rdm.c
@@ -13,6 +13,10 @@
 #include "private/rdm_encode/functions.h"
 #include "private/rdm_encode/types.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "esp_mac.h"
+#endif
+
 // Used for argument checking at the beginning of each function.
 #define RDM_CHECK(a, err_code, format, ...) \
   ESP_RETURN_ON_FALSE(a, err_code, TAG, format, ##__VA_ARGS__)

--- a/src/esp_rdm.h
+++ b/src/esp_rdm.h
@@ -11,11 +11,19 @@
 extern "C" {
 #endif
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+/**
+ * @brief The recommended method for representing the UID in text by separating
+ * the manufacturer ID and the device ID. For use with printf-like functions.
+ */
+#define UIDSTR "%04x:%08lx"
+#else
 /**
  * @brief The recommended method for representing the UID in text by separating
  * the manufacturer ID and the device ID. For use with printf-like functions.
  */
 #define UIDSTR "%04x:%08x"
+#endif
 
 /**
  * @brief Used to generate arguments for the UIDSTR macro for representing the

--- a/src/private/dmx_hal.h
+++ b/src/private/dmx_hal.h
@@ -18,6 +18,10 @@
 #include "driver.h"
 #include "hal/uart_hal.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "esp_private/esp_clk.h"
+#endif
+
 #ifdef CONFIG_DMX_ISR_IN_IRAM
 #define DMX_ISR_ATTR IRAM_ATTR
 #else
@@ -36,7 +40,11 @@ extern "C" {
 void dmx_uart_init(uart_dev_t *uart) {
   // Configure the UART for DMX output
   uart_ll_set_sclk(uart, UART_SCLK_APB);
+#if ESP_IDF_VERSION_MAJOR >= 5
+  uart_ll_set_baudrate(uart, DMX_BAUD_RATE, esp_clk_apb_freq());
+#else
   uart_ll_set_baudrate(uart, DMX_BAUD_RATE);
+#endif
   uart_ll_set_mode(uart, UART_MODE_RS485_HALF_DUPLEX);
   uart_ll_set_parity(uart, UART_PARITY_DISABLE);
   uart_ll_set_data_bit_num(uart, UART_DATA_8_BITS);
@@ -60,7 +68,11 @@ void dmx_uart_init(uart_dev_t *uart) {
  * @return The baud rate of the UART hardware.
  */
 uint32_t dmx_uart_get_baud_rate(uart_dev_t *uart) {
+#if ESP_IDF_VERSION_MAJOR >= 5
+  return uart_ll_get_baudrate(uart, esp_clk_apb_freq());
+#else
   return uart_ll_get_baudrate(uart);
+#endif
 }
 
 /**
@@ -70,7 +82,11 @@ uint32_t dmx_uart_get_baud_rate(uart_dev_t *uart) {
  * @param baud_rate The baud rate to use.
  */
 void dmx_uart_set_baud_rate(uart_dev_t *uart, uint32_t baud_rate) {
+#if ESP_IDF_VERSION_MAJOR >= 5
+  uart_ll_set_baudrate(uart, baud_rate, esp_clk_apb_freq());
+#else
   uart_ll_set_baudrate(uart, baud_rate);
+#endif
 }
 
 /**

--- a/src/private/driver.h
+++ b/src/private/driver.h
@@ -3,13 +3,20 @@
 #include <stdint.h>
 
 #include "dmx_types.h"
-#include "driver/timer.h"
 #include "esp_err.h"
 #include "esp_intr_alloc.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "hal/uart_hal.h"
+
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "driver/gptimer.h"
+// TODO: replacement for "driver/periph_ctrl.h"
+#else
+#include "driver/timer.h"
+#include "driver/periph_ctrl.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,7 +33,7 @@ typedef __attribute__((aligned(4))) struct dmx_driver_t {
   uart_dev_t *restrict uart;      // A pointer to the UART port.
   intr_handle_t uart_isr_handle;  // The handle to the DMX UART ISR.
 
-#if ESP_IDF_MAJOR_VERSION >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5
 #error ESP-IDF v5 not supported yet!
   // TODO
 #else

--- a/src/private/driver.h
+++ b/src/private/driver.h
@@ -32,8 +32,7 @@ typedef __attribute__((aligned(4))) struct dmx_driver_t {
   intr_handle_t uart_isr_handle;  // The handle to the DMX UART ISR.
 
 #if ESP_IDF_VERSION_MAJOR >= 5
-#error ESP-IDF v5 not supported yet!
-  // TODO
+  gptimer_handle_t gptimer_handle;  // The general purpose timer to use for DMX functions.
 #else
   timer_group_t timer_group;  // The timer group to use for DMX functions.
   timer_idx_t timer_idx;      // The timer index to use for DMX functions.

--- a/src/private/driver.h
+++ b/src/private/driver.h
@@ -12,10 +12,8 @@
 
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include "driver/gptimer.h"
-// TODO: replacement for "driver/periph_ctrl.h"
 #else
 #include "driver/timer.h"
-#include "driver/periph_ctrl.h"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This adds support for the newly released ESP-IDF v5. This addition primarily features the new GPTimer API for controlling the hardware, high-resolution timer. The high-resolution timer is used for RDM timing specification as well as DMX break and mark-after-break.