### PR TITLE
PlatformIO v6.0 compatibility

### DIFF
--- a/examples/idf_rdm_discovery/idf_rdm_discovery.c
+++ b/examples/idf_rdm_discovery/idf_rdm_discovery.c
@@ -30,7 +30,6 @@
 #define TX_PIN 17  // The DMX transmit pin.
 #define RX_PIN 16  // The DMX receive pin.
 #define EN_PIN 21  // The DMX transmit enable pin.
-#define SN_PIN 4   // The DMX sniffer pin.
 
 static const char *TAG = "main";
 

--- a/examples/idf_rdm_discovery/idf_rdm_discovery.c
+++ b/examples/idf_rdm_discovery/idf_rdm_discovery.c
@@ -11,7 +11,7 @@
 
   Discovery can take several seconds to complete, especially when there are
   several responder devices on the RDM network. In this example, the amount of
-  time that discovery takes is measured and logged to the terminal. 
+  time that discovery takes is measured and logged to the terminal.
 
   Note: this example is for use with the ESP-IDF. It will not work on Arduino!
 

--- a/examples/idf_rdm_discovery/idf_rdm_discovery.c
+++ b/examples/idf_rdm_discovery/idf_rdm_discovery.c
@@ -24,6 +24,7 @@
 #include "esp_dmx.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 #include "freertos/task.h"
 
 #define TX_PIN 17  // The DMX transmit pin.

--- a/examples/idf_read/idf_read.c
+++ b/examples/idf_read/idf_read.c
@@ -40,7 +40,6 @@ void app_main() {
 
   TickType_t last_update = xTaskGetTickCount();
   while (true) {
-
     // Block until a packet is received
     if (dmx_receive(dmx_num, &packet, DMX_TIMEOUT_TICK)) {
       const TickType_t now = xTaskGetTickCount();
@@ -58,7 +57,7 @@ void app_main() {
         ESP_LOG_BUFFER_HEX(TAG, data, 16);  // Log first 16 bytes
         last_update = now;
       }
-      
+
     } else if (is_connected) {
       // DMX timed out after having been previously connected
       ESP_LOGI(TAG, "DMX was disconnected.");

--- a/examples/idf_sniffer/idf_sniffer.c
+++ b/examples/idf_sniffer/idf_sniffer.c
@@ -56,7 +56,7 @@ void app_main() {
 
       if (now - last_update >= pdMS_TO_TICKS(1000)) {
         // Only log data every 1000ms
-        ESP_LOGI(TAG, "Break: %i, MAB: %i", metadata.break_len,
+        ESP_LOGI(TAG, "Break: %li, MAB: %li", metadata.break_len,
                  metadata.mab_len);
         last_update = now;
       }

--- a/examples/idf_write/idf_write.c
+++ b/examples/idf_write/idf_write.c
@@ -27,7 +27,6 @@ static const char *TAG = "main";
 static uint8_t data[DMX_PACKET_SIZE] = {};  // Buffer to store DMX data
 
 void app_main() {
-  // use DMX port 2
   const dmx_port_t dmx_num = DMX_NUM_2;
 
   // Set communication pins and install the driver
@@ -51,7 +50,7 @@ void app_main() {
       ESP_LOGI(TAG, "Incremented packet slots to 0x%02x", data[1]);
       last_update = now;
     }
-    
+
     // Only send a packet every 30ms
     vTaskDelayUntil(&now, pdMS_TO_TICKS(30));
   }

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -34,7 +34,7 @@
 #define DMX_CHECK(a, err_code, format, ...) \
   ESP_RETURN_ON_FALSE(a, err_code, TAG, format, ##__VA_ARGS__)
 
-DRAM_ATTR dmx_driver_t *restrict dmx_driver[DMX_NUM_MAX] = {0};
+DRAM_ATTR dmx_driver_t *dmx_driver[DMX_NUM_MAX] = {0};
 DRAM_ATTR spinlock_t dmx_spinlock[DMX_NUM_MAX] = {portMUX_INITIALIZER_UNLOCKED,
                                                   portMUX_INITIALIZER_UNLOCKED,
 #if DMX_NUM_MAX > 2

--- a/src/private/dmx_hal.h
+++ b/src/private/dmx_hal.h
@@ -289,7 +289,7 @@ DMX_ISR_ATTR void dmx_uart_write_txfifo(uart_dev_t *uart, const void *buf,
                                         size_t *size) {
   const size_t txfifo_len = uart_ll_get_txfifo_len(uart);
   if (*size > txfifo_len) *size = txfifo_len;
-  uart_ll_write_txfifo(uart, buf, *size);
+  uart_ll_write_txfifo(uart, (uint8_t *)buf, *size);
 }
 
 /**

--- a/src/private/driver.h
+++ b/src/private/driver.h
@@ -28,7 +28,7 @@ extern "C" {
 typedef __attribute__((aligned(4))) struct dmx_driver_t {
   dmx_port_t dmx_num;  // The driver's DMX port number.
 
-  uart_dev_t *restrict uart;      // A pointer to the UART port.
+  uart_dev_t *uart;               // A pointer to the UART port.
   intr_handle_t uart_isr_handle;  // The handle to the DMX UART ISR.
 
 #if ESP_IDF_VERSION_MAJOR >= 5
@@ -79,7 +79,7 @@ typedef __attribute__((aligned(4))) struct dmx_driver_t {
   } sniffer;
 } dmx_driver_t;
 
-extern dmx_driver_t *restrict dmx_driver[DMX_NUM_MAX];
+extern dmx_driver_t *dmx_driver[DMX_NUM_MAX];
 extern spinlock_t dmx_spinlock[DMX_NUM_MAX];
 
 #ifdef __cplusplus


### PR DESCRIPTION
This fixes some issues with PlatformIO compatibility since PlatformIO now uses ESP-IDF v5.0.