### PR TITLE
allow gptimer to fail gracefully

### DIFF
--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -488,7 +488,12 @@ esp_err_t dmx_driver_install(dmx_port_t dmx_num, int intr_flags) {
       .direction = GPTIMER_COUNT_UP,
       .resolution_hz = 1000000,  // 1MHz resolution timer
   };
-  gptimer_new_timer(&timer_config, &driver->gptimer_handle);  // TODO: err check
+  esp_err_t err = gptimer_new_timer(&timer_config, &driver->gptimer_handle);
+  if (err) {
+    ESP_LOGE(TAG, "DMX driver gptimer error");
+    dmx_driver_delete(dmx_num);
+    return err;
+  }
   const gptimer_event_callbacks_t gptimer_cb = {.on_alarm = dmx_timer_isr};
   gptimer_register_event_callbacks(driver->gptimer_handle, &gptimer_cb, driver);
   gptimer_enable(driver->gptimer_handle);


### PR DESCRIPTION
This PR adds a an error check when calling gptimer_new_timer() inside dmx_driver_install(). It simply checks to see if an error occurred when creating a new gptimer and allows the driver installation to fail if needed.