### PR TITLE
Allow enabling and disabling the driver

### DIFF
--- a/src/esp_dmx.h
+++ b/src/esp_dmx.h
@@ -69,10 +69,49 @@ esp_err_t dmx_driver_delete(dmx_port_t dmx_num);
  * */
 bool dmx_driver_is_installed(dmx_port_t dmx_num);
 
+/**
+ * @brief Disables the DMX driver. When the DMX driver is not placed in IRAM,
+ * functions which disable the cache, such as functions which read or write to
+ * flash, will also stop DMX interrupts from firing. This can cause incoming DMX
+ * data to become corrupted. To avoid this issue, the DMX driver should be
+ * disabled before disabling the cache. When cache is reenabled, the DMX driver
+ * can be reenabled as well. When the DMX driver is placed in IRAM, disabling
+ * and reenabling the DMX driver is not needed.
+ * 
+ * @param dmx_num The DMX port number.
+ * @retval true if the driver was disabled.
+ * @retval false if the driver was not disabled.
+ */
 bool dmx_driver_disable(dmx_port_t dmx_num);
 
+/**
+ * @brief Enables the DMX driver. When the DMX driver is not placed in IRAM,
+ * functions which disable the cache, such as functions which read or write to
+ * flash, will also stop DMX interrupts from firing. This can cause incoming DMX
+ * data to become corrupted. To avoid this issue, the DMX driver should be
+ * disabled before disabling the cache. When cache is reenabled, the DMX driver
+ * can be reenabled as well. When the DMX driver is placed in IRAM, disabling
+ * and reenabling the DMX driver is not needed.
+ * 
+ * @param dmx_num The DMX port number.
+ * @retval true if the driver was enabled.
+ * @retval false if the driver was enabled.
+ */
 bool dmx_driver_enable(dmx_port_t dmx_num);
 
+/**
+ * @brief Checks if the DMX driver is enabled. When the DMX driver is not placed
+ * in IRAM, functions which disable the cache, such as functions which read or
+ * write to flash, will also stop DMX interrupts from firing. This can cause
+ * incoming DMX data to become corrupted. To avoid this issue, the DMX driver
+ * should be disabled before disabling the cache. When cache is reenabled, the
+ * DMX driver can be reenabled as well. When the DMX driver is placed in IRAM,
+ * disabling and reenabling the DMX driver is not needed.
+ *
+ * @param dmx_num The DMX port number.
+ * @retval true if the driver is enabled.
+ * @retval false if the driver is disabled.
+ */
 bool dmx_driver_is_enabled(dmx_port_t dmx_num);
 
 /**

--- a/src/esp_dmx.h
+++ b/src/esp_dmx.h
@@ -69,6 +69,12 @@ esp_err_t dmx_driver_delete(dmx_port_t dmx_num);
  * */
 bool dmx_driver_is_installed(dmx_port_t dmx_num);
 
+bool dmx_driver_disable(dmx_port_t dmx_num);
+
+bool dmx_driver_enable(dmx_port_t dmx_num);
+
+bool dmx_driver_is_enabled(dmx_port_t dmx_num);
+
 /**
  * @brief Sets DMX pin number.
  *

--- a/src/private/driver.h
+++ b/src/private/driver.h
@@ -58,6 +58,7 @@ typedef __attribute__((aligned(4))) struct dmx_driver_t {
   int end_of_packet;  // True if the driver received an end-of-packet condition.
   int is_sending;     // True if the driver is sending data.
   int new_packet;     // True if the driver has a new, unhandled packet.
+  int is_enabled;     // True if the driver is enabled.
 
   TaskHandle_t task_waiting;  // The handle to a task that is waiting for data to be sent or received.
   SemaphoreHandle_t mux;      // The handle to the driver mutex which allows multi-threaded driver function calls.


### PR DESCRIPTION
Allow for the driver to be enabled and disabled. This can prevent issues when disabling cache while the DMX driver is not placed in IRAM.