### PR TITLE
Add library version numbers.

### DIFF
--- a/src/esp_dmx.h
+++ b/src/esp_dmx.h
@@ -15,6 +15,15 @@
 #include "driver/gpio.h"
 #include "freertos/FreeRTOS.h"
 
+/** @brief The major version number of this library. (X.x.x)*/
+#define ESP_DMX_VERSION_MAJOR 3
+
+/** @brief The minor version number of this library. (x.X.x)*/
+#define ESP_DMX_VERSION_MINOR 0
+
+/** @brief The patch version number of this library. (x.x.X)*/
+#define ESP_DMX_VERSION_PATCH 3
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This PR adds version number macros to `esp_dmx.h` and attaches them to the RDM responder callbacks.