### PR TITLE
Do not increase parameter callback count when an existing callback is overwritten

### DIFF
--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -267,7 +267,12 @@ bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
   driver->rdm_cbs[i].user_cb = user_cb;
   driver->rdm_cbs[i].driver_cb = driver_cb;
   driver->rdm_cbs[i].desc = *desc;
-  ++driver->num_rdm_cbs;
+
+  bool newCallback = i == driver->num_rdm_cbs;
+  if(newCallback)
+  {
+    ++driver->num_rdm_cbs;
+  }
 
   return true;
 }


### PR DESCRIPTION
I stumbled upon this while reading the code :-)
As far as I understand `rdm_register_parameter` allows for overwriting existing callbacks.
In that case `i` would point to the existing callback and the number of callbacks should not increase.
However the number of callbacks was always increased. This is fixed by this PR