### PR TITLE
fix: do not invoke user_cb for unknown rdm pids

### DIFF
--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -1084,7 +1084,7 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
   }
 
   // Call the user-side callback
-  if (driver->rdm_cbs[cb_num].user_cb != NULL) {
+  if (cb_num < driver->num_rdm_cbs && driver->rdm_cbs[cb_num].user_cb != NULL) {
     void *context = driver->rdm_cbs[cb_num].context;
     driver->rdm_cbs[cb_num].user_cb(dmx_num, &header, context);
   }


### PR DESCRIPTION
When asking for a pid that is not supported, the code tries to invoke a user_cb that doesn't exist. This is fixed by this PR