### PR TITLE
Implement RDM_PID_SUPPORTED_PARAMETERS

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -61,12 +61,12 @@ menu "DMX/RDM Configuration"
             instructs the DMX driver to allocate the needed memory on the stack
             instead of heap allocating it.
            
-    config RDM_RESPONDER_MAX_PARAMETERS
-        int "Max RDM responder PIDs"
+    config RDM_RESPONDER_MAX_OPTIONAL_PARAMETERS
+        int "Max RDM responder optional PIDs"
         range 0 512
         default 16
         help
-            This is the maximum number of RDM parameter responses that the DMX
+            This is the maximum number of optional RDM parameter responses that the DMX
             driver supports. Increasing this number increases the size of the
             DMX driver.
 

--- a/src/dmx/config.h
+++ b/src/dmx/config.h
@@ -58,22 +58,19 @@ extern "C" {
 #define RDM_UID_DEVICE_ID (0xffffffff)
 #endif
 
-#ifdef CONFIG_RDM_RESPONDER_MAX_PARAMETERS
-/** @brief The maximum number of parameters that the RDM responder can
+#define RDM_RESPONDER_NUM_PIDS_REQUIRED 9
+
+#ifdef CONFIG_RDM_RESPONDER_MAX_OPTIONAL_PARAMETERS
+/** @brief The maximum number of optional parameters that the RDM responder can
  * support. This value is editable in the Kconfig.*/
-#define RDM_RESPONDER_PIDS_MAX (8 + CONFIG_RDM_RESPONDER_MAX_PARAMETERS)
+#define RDM_RESPONDER_NUM_PIDS_OPTIONAL (CONFIG_RDM_RESPONDER_MAX_OPTIONAL_PARAMETERS)
 #else
-/** @brief The maximum number of parameters that the RDM responder can
- * support.*/
-#define RDM_RESPONDER_PIDS_MAX (8 + 16)
+#define RDM_RESPONDER_NUM_PIDS_OPTIONAL 25
 #endif
 
-/** @brief The maximum number of additional parameters that is supported.
- *  
- * According to ANSI-E1-20-2010 we can support up to 115 additional parameters.
- * In practice we will never need that many, thus we limit it to save memory.
-*/
-#define RDM_MAX_NUM_ADDITIONAL_PARAMETERS 25
+/** @brief The maximum number of parameters that the RDM responder can
+ * support.*/
+#define RDM_RESPONDER_PIDS_MAX (RDM_RESPONDER_NUM_PIDS_REQUIRED + RDM_RESPONDER_NUM_PIDS_OPTIONAL)
 
 /** @brief Directs the DMX driver to use spinlocks in critical sections. This is
  * needed for devices which have multiple cores.*/

--- a/src/dmx/config.h
+++ b/src/dmx/config.h
@@ -68,6 +68,13 @@ extern "C" {
 #define RDM_RESPONDER_PIDS_MAX (8 + 16)
 #endif
 
+/** @brief The maximum number of additional parameters that is supported.
+ *  
+ * According to ANSI-E1-20-2010 we can support up to 115 additional parameters.
+ * In practice we will never need that many, thus we limit it to save memory.
+*/
+#define RDM_MAX_NUM_ADDITIONAL_PARAMETERS 25
+
 /** @brief Directs the DMX driver to use spinlocks in critical sections. This is
  * needed for devices which have multiple cores.*/
 #define DMX_USE_SPINLOCK

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -451,6 +451,7 @@ bool dmx_driver_install(dmx_port_t dmx_num, const dmx_config_t *config,
         .sub_device_count = 0,  // Sub-devices must be registered
         .sensor_count = 0,      // Sensors must be registered
     };
+    rdm_register_supported_parameters(dmx_num, NULL, NULL);
     rdm_register_disc_unique_branch(dmx_num, NULL, NULL);
     rdm_register_disc_un_mute(dmx_num, NULL, NULL);
     rdm_register_disc_mute(dmx_num, NULL, NULL);

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -204,7 +204,7 @@ static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
   uint16_t *params = (uint16_t*)param;
 
   int i = 0;
-  for(; i < RDM_MAX_NUM_ADDITIONAL_PARAMETERS; i++) {
+  for(; i < RDM_RESPONDER_NUM_PIDS_OPTIONAL; i++) {
     if(params[i] == 0) {
       break;
     }
@@ -364,7 +364,7 @@ bool rdm_register_supported_parameters(dmx_port_t dmx_num, rdm_responder_cb_t cb
   DMX_CHECK(dmx_num < DMX_NUM_MAX, false, "dmx_num error");
   DMX_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
-  const uint16_t size = RDM_MAX_NUM_ADDITIONAL_PARAMETERS * sizeof(uint16_t);
+  const uint16_t size = RDM_RESPONDER_NUM_PIDS_OPTIONAL * sizeof(uint16_t);
   uint16_t *param = rdm_pd_find(dmx_num, RDM_PID_SUPPORTED_PARAMETERS);
   if (param == NULL) {
     param = rdm_pd_alloc(dmx_num, size);

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -188,9 +188,6 @@ static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
                                             const rdm_pid_description_t *desc,
                                             const char *param_str) 
 {
-  DMX_CHECK(dmx_num < DMX_NUM_MAX, RDM_RESPONSE_TYPE_NONE, "dmx_num error");
-  DMX_CHECK(dmx_driver_is_installed(dmx_num), RDM_RESPONSE_TYPE_NONE, "driver is not installed");
-
   // Return early if the sub-device is out of range
   if (header->sub_device != RDM_SUB_DEVICE_ROOT) {
     *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_SUB_DEVICE_OUT_OF_RANGE);
@@ -215,8 +212,6 @@ static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
     pd += sizeof(uint16_t);
   }
   *pdl_out = i * sizeof(uint16_t);
-
-  ESP_LOGE(TAG, "NUM OF ADDITIONAL PARAMS: %d\n", i);
 
   return RDM_RESPONSE_TYPE_ACK;
 }
@@ -381,7 +376,7 @@ bool rdm_register_supported_parameters(dmx_port_t dmx_num, rdm_responder_cb_t cb
 
   const rdm_pid_description_t desc = {.pid = RDM_PID_SUPPORTED_PARAMETERS,
                                       .pdl_size = size,
-                                      .data_type = RDM_DS_NOT_DEFINED,
+                                      .data_type = RDM_DS_UNSIGNED_WORD,
                                       .cc = RDM_CC_GET,
                                       .unit = RDM_UNITS_NONE,
                                       .prefix = RDM_PREFIX_NONE,

--- a/src/rdm/responder.h
+++ b/src/rdm/responder.h
@@ -122,6 +122,10 @@ bool rdm_register_software_version_label(dmx_port_t dmx_num,
 bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                   void *context);
 
+
+bool rdm_register_supported_parameters(dmx_port_t dmx_num, rdm_responder_cb_t cb,
+                                  void *context);
+
 /**
  * @brief Registers the default response to RDM_PID_DMX_START_ADDRESS requests.
  * This response is required by all RDM-capable devices which use a DMX address.

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -248,8 +248,8 @@ static bool rdm_add_supported_parameter(dmx_port_t dmx_num, uint16_t pid)
     if(param[i] == 0)
     {
       param[i] = pid;
+      return true;
     }
-    return true;
   }
 
   ESP_LOGE(TAG, "Not space left in parameter list. Increase RDM_MAX_NUM_ADDITIONAL_PARAMETERS and recompile");

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -237,7 +237,7 @@ static bool rdm_add_supported_parameter(dmx_port_t dmx_num, uint16_t pid)
   }
 
   //find next free slot in parameter list and insert the pid
-  for(int i = 0; i < RDM_MAX_NUM_ADDITIONAL_PARAMETERS; i++)
+  for(int i = 0; i < RDM_RESPONDER_NUM_PIDS_OPTIONAL; i++)
   {
     if(param[i] == pid)
     {


### PR DESCRIPTION
I want to support more parameters, to be able to do that the `PID_SUPPORTED_PARAMETERS` must be supported.
This is implemented by this PR.
I am not sure that this is the best way to do it. Please feel free to point out any mistakes or strange things. I am not very familiar with your code base and might have overlooked a more obvious solution.

This requires https://github.com/someweisguy/esp_dmx/pull/89 to be merged first

On top of this, I am currently implementing support for `PID_DMX_PERSONALITY` and will provide a PR within the next 1-2 days :)
