### PR TITLE
Add RDM queue

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -66,8 +66,17 @@ menu "DMX/RDM Configuration"
         range 0 512
         default 16
         help
-            This is the maximum number of optional RDM parameter responses that the DMX
-            driver supports. Increasing this number increases the size of the
-            DMX driver.
+            This is the maximum number of optional RDM parameter responses that 
+            the DMX driver supports. Increasing this number increases the size
+            of the DMX driver.
+    
+    config RDM_RESPONDER_MAX_QUEUE_SIZE
+        int "Max RDM responder queue size"
+        range 0 65535
+        default 32
+        help
+           This is the maximum number of queued messages which the DMX driver
+           supports. Increasing this number increases the size of the DMX 
+           driver.
 
 endmenu

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Response information from requests is read into a `rdm_ack_t` pointer which is p
 - `err` evaluates to `true` if an error occurred reading DMX data. This field only indicates if an error occurred reading raw DMX data. It does not indicate if an invalid RDM packet was received. More information on error handling can be found in the [Error Handling](#error-handling) section.
 - `size` is the size of the received packet, including start code, RDM sub-start code, and checksum.
 - `src_uid` is the UID of the device originating the response packet.
+- `pid` is the PID of the response packet. This is typically the same as the PID which was sent in the request, but may differ for some requests.
 - `type` is the type of the RDM response received. It can be any of the RDM response types enumerated in [Response Types](#response-types).
 - `message_count` is used by an RDM responder to indicate that additional data is now available for collection by a controller.
 

--- a/src/dmx/config.h
+++ b/src/dmx/config.h
@@ -72,6 +72,18 @@ extern "C" {
  * support.*/
 #define RDM_RESPONDER_PIDS_MAX (RDM_RESPONDER_NUM_PIDS_REQUIRED + RDM_RESPONDER_NUM_PIDS_OPTIONAL)
 
+#ifdef CONFIG_RDM_RESPONDER_MAX_QUEUE_SIZE
+/** @brief The maximum number of queued messages that ther RDM responder can 
+ * support. It may be set using the Kconfig file.
+ */
+#define RDM_RESPONDER_MAX_QUEUE_SIZE CONFIG_RDM_RESPONDER_MAX_QUEUE_SIZE
+#else
+/** @brief The maximum number of queued messages that ther RDM responder can 
+ * support.
+ */
+#define RDM_RESPONDER_MAX_QUEUE_SIZE 64
+#endif
+
 /** @brief Directs the DMX driver to use spinlocks in critical sections. This is
  * needed for devices which have multiple cores.*/
 #define DMX_USE_SPINLOCK

--- a/src/dmx/config.h
+++ b/src/dmx/config.h
@@ -82,7 +82,7 @@ extern "C" {
 /** @brief The maximum number of queued messages that ther RDM responder can 
  * support. It may be set using the Kconfig file.
  */
-#define RDM_RESPONDER_MAX_QUEUE_SIZE CONFIG_RDM_RESPONDER_MAX_QUEUE_SIZE
+#define RDM_RESPONDER_QUEUE_SIZE_MAX CONFIG_RDM_RESPONDER_MAX_QUEUE_SIZE
 #else
 /** @brief The maximum number of queued messages that ther RDM responder can 
  * support.

--- a/src/dmx/config.h
+++ b/src/dmx/config.h
@@ -20,6 +20,12 @@ extern "C" {
   ESP_RETURN_ON_FALSE(a, err_code, TAG, format, ##__VA_ARGS__)
 
 /** @brief Logs a warning message on the terminal if the condition is not met.*/
+#define DMX_ERR(format, ...)              \
+  do {                                    \
+    ESP_LOGE(TAG, format, ##__VA_ARGS__); \
+  } while (0);
+
+/** @brief Logs a warning message on the terminal if the condition is not met.*/
 #define DMX_WARN(format, ...)             \
   do {                                    \
     ESP_LOGW(TAG, format, ##__VA_ARGS__); \

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -1068,8 +1068,10 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
   header.dest_uid = header.src_uid;
   header.src_uid = my_uid;
   header.response_type = response_type;
-  header.message_count = 0;  // TODO: update this if messages are queued
-  header.cc += 1;            // Set to RDM_CC_x_COMMAND_RESPONSE
+  taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
+  header.message_count = driver->rdm_queue_size;
+  taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
+  header.cc += 1;  // Set to RDM_CC_x_COMMAND_RESPONSE
   header.pdl = pdl_out;
   // These fields should not change: tn, sub_device, and pid
 

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -290,7 +290,8 @@ static void DMX_ISR_ATTR dmx_gpio_isr(void *arg) {
 static void rdm_default_identify_cb(dmx_port_t dmx_num,
                                     const rdm_header_t *header, void *context) {
   if (header->cc == RDM_CC_SET_COMMAND) {
-    const uint8_t *identify = rdm_pd_find(dmx_num, RDM_PID_IDENTIFY_DEVICE);
+    const uint8_t *identify =
+        rdm_get_parameter(dmx_num, RDM_PID_IDENTIFY_DEVICE, header->sub_device);
 #ifdef ARDUINO
     printf("RDM identify device is %s\n", *identify ? "on" : "off");
 #else
@@ -679,8 +680,8 @@ bool dmx_set_start_address(dmx_port_t dmx_num, uint16_t dmx_start_address) {
   const bool rdm_is_enabled = (dmx_driver[dmx_num]->pd_size >= 53);
 
   if (rdm_is_enabled) {
-    rdm_set_parameter(dmx_num, RDM_PID_DMX_START_ADDRESS, &dmx_start_address,
-                      sizeof(uint16_t), true);
+    rdm_set_parameter(dmx_num, RDM_PID_DMX_START_ADDRESS, RDM_SUB_DEVICE_ROOT,
+                      &dmx_start_address, sizeof(uint16_t), true);
   } else {
     taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
     dmx_driver_personality_t *personality = (void *)dmx_driver[dmx_num]->pd;

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -1077,7 +1077,7 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
   }
 
   // Update NVS values
-  if (driver->rdm_cbs[cb_num].nvs) {
+  if (driver->rdm_cbs[cb_num].non_volatile) {
     if (!dmx_nvs_set(dmx_num, header.pid, desc->data_type, param,
                      desc->pdl_size)) {
       taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -291,7 +291,7 @@ static void rdm_default_identify_cb(dmx_port_t dmx_num,
                                     const rdm_header_t *header, void *context) {
   if (header->cc == RDM_CC_SET_COMMAND) {
     const uint8_t *identify =
-        rdm_get_parameter(dmx_num, RDM_PID_IDENTIFY_DEVICE, header->sub_device);
+        rdm_pd_get(dmx_num, RDM_PID_IDENTIFY_DEVICE, header->sub_device);
 #ifdef ARDUINO
     printf("RDM identify device is %s\n", *identify ? "on" : "off");
 #else
@@ -680,7 +680,7 @@ bool dmx_set_start_address(dmx_port_t dmx_num, uint16_t dmx_start_address) {
   const bool rdm_is_enabled = (dmx_driver[dmx_num]->pd_size >= 53);
 
   if (rdm_is_enabled) {
-    rdm_set_parameter(dmx_num, RDM_PID_DMX_START_ADDRESS, RDM_SUB_DEVICE_ROOT,
+    rdm_pd_set(dmx_num, RDM_PID_DMX_START_ADDRESS, RDM_SUB_DEVICE_ROOT,
                       &dmx_start_address, sizeof(uint16_t), true);
   } else {
     taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -1003,7 +1003,7 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
     dmx_read_rdm(dmx_num, NULL, pd, sizeof(pd));
     const char *param_str = driver->rdm_cbs[cb_num].param_str;
     response_type = driver->rdm_cbs[cb_num].driver_cb(
-        dmx_num, &header, pd, &pdl_out, desc, param_str);
+        dmx_num, &header, pd, &pdl_out, param_str);
 
     // Verify that the driver-side callback returned correctly
     if (pdl_out > sizeof(pd)) {

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -1003,7 +1003,7 @@ size_t dmx_receive(dmx_port_t dmx_num, dmx_packet_t *packet,
     dmx_read_rdm(dmx_num, NULL, pd, sizeof(pd));
     const char *param_str = driver->rdm_cbs[cb_num].param_str;
     response_type = driver->rdm_cbs[cb_num].driver_cb(
-        dmx_num, &header, pd, &pdl_out, param, desc, param_str);
+        dmx_num, &header, pd, &pdl_out, desc, param_str);
 
     // Verify that the driver-side callback returned correctly
     if (pdl_out > sizeof(pd)) {

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -680,8 +680,7 @@ bool dmx_set_start_address(dmx_port_t dmx_num, uint16_t dmx_start_address) {
 
   if (rdm_is_enabled) {
     rdm_set_parameter(dmx_num, RDM_PID_DMX_START_ADDRESS, &dmx_start_address,
-                      sizeof(uint16_t),
-                      RDM_PARAMETER_FLAG_NVS | RDM_PARAMETER_FLAG_QUEUE);
+                      sizeof(uint16_t), true);
   } else {
     taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
     dmx_driver_personality_t *personality = (void *)dmx_driver[dmx_num]->pd;

--- a/src/dmx/hal.c
+++ b/src/dmx/hal.c
@@ -418,6 +418,8 @@ bool dmx_driver_install(dmx_port_t dmx_num, const dmx_config_t *config,
   driver->pd_head = 0;
 
   // RDM responder configuration
+  driver->rdm_queue_size = 0;
+  driver->rdm_queue_last_sent = 0;  // A queued message has not yet been sent
   driver->num_rdm_cbs = 0;
   // The driver->rdm_cbs field is left uninitialized
 

--- a/src/dmx/struct.h
+++ b/src/dmx/struct.h
@@ -111,7 +111,7 @@ typedef struct dmx_driver_t {
 
   uint16_t rdm_queue_last_sent;  // The PID of the last sent queued message.
   uint16_t rdm_queue_size;  // The index of the RDM message queue list.
-  uint16_t rdm_queue[RDM_RESPONDER_MAX_QUEUE_SIZE];  // The RDM queued message list.
+  uint16_t rdm_queue[RDM_RESPONDER_QUEUE_SIZE_MAX];  // The RDM queued message list.
 
   // DMX sniffer configuration
   dmx_metadata_t metadata;  // The metadata received by the DMX sniffer.

--- a/src/dmx/struct.h
+++ b/src/dmx/struct.h
@@ -43,6 +43,12 @@ enum dmx_flags_t {
   DMX_FLAGS_RDM_IS_DISC_UNIQUE_BRANCH = BIT4,  // The RDM packet is a DISC_UNIQUE_BRANCH.
 };
 
+typedef struct rdm_pid_info_t {
+  rdm_pid_description_t desc;
+  const char *param_str;
+  bool is_persistent;
+} rdm_pid_info_t;
+
 /**
  * @brief Stores the DMX personality information of the DMX driver when RDM is
  * not enabled.*/
@@ -96,7 +102,7 @@ typedef struct dmx_driver_t {
   struct rdm_cb_table_t {
     rdm_pid_description_t desc;  // The parameter description.
     const char *param_str;       // A parameter string describing the data.
-    bool nvs;                    // True if the parameter is non-volatile.
+    bool non_volatile;                    // True if the parameter is non-volatile.
     rdm_driver_cb_t driver_cb;   // The driver-side callback function.
     rdm_responder_cb_t user_cb;  // The user-side callback function.
     void *param;                 // A pointer to the parameter data.

--- a/src/dmx/struct.h
+++ b/src/dmx/struct.h
@@ -100,6 +100,7 @@ typedef struct dmx_driver_t {
     rdm_driver_cb_t driver_cb;   // The driver-side callback function.
     rdm_responder_cb_t user_cb;  // The user-side callback function.
     void *context;               // The contexted for the user-side callback.
+    bool nvs;                    // True if the parameter is non-volatile.
   } rdm_cbs[RDM_RESPONDER_PIDS_MAX];  // A table containing information on RDM callbacks.
 
   uint16_t rdm_queue_last_sent;  // The PID of the last sent queued message.

--- a/src/dmx/struct.h
+++ b/src/dmx/struct.h
@@ -95,12 +95,12 @@ typedef struct dmx_driver_t {
   size_t num_rdm_cbs;            // The number of RDM callbacks registered.
   struct rdm_cb_table_t {
     rdm_pid_description_t desc;  // The parameter description.
-    void *param;                 // A pointer to the parameter data.
     const char *param_str;       // A parameter string describing the data.
+    bool nvs;                    // True if the parameter is non-volatile.
     rdm_driver_cb_t driver_cb;   // The driver-side callback function.
     rdm_responder_cb_t user_cb;  // The user-side callback function.
+    void *param;                 // A pointer to the parameter data.
     void *context;               // The contexted for the user-side callback.
-    bool nvs;                    // True if the parameter is non-volatile.
   } rdm_cbs[RDM_RESPONDER_PIDS_MAX];  // A table containing information on RDM callbacks.
 
   uint16_t rdm_queue_last_sent;  // The PID of the last sent queued message.

--- a/src/dmx/struct.h
+++ b/src/dmx/struct.h
@@ -102,6 +102,10 @@ typedef struct dmx_driver_t {
     void *context;               // The contexted for the user-side callback.
   } rdm_cbs[RDM_RESPONDER_PIDS_MAX];  // A table containing information on RDM callbacks.
 
+  uint16_t rdm_queue_last_sent;  // The PID of the last sent queued message.
+  uint16_t rdm_queue_size;  // The index of the RDM message queue list.
+  uint16_t rdm_queue[RDM_RESPONDER_MAX_QUEUE_SIZE];  // The RDM queued message list.
+
   // DMX sniffer configuration
   dmx_metadata_t metadata;  // The metadata received by the DMX sniffer.
   QueueHandle_t metadata_queue;  // The queue handle used to receive sniffer data.

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -87,8 +87,8 @@ uint8_t dmx_get_current_personality(dmx_port_t dmx_num) {
 
   uint8_t current_personality;
 
-  const rdm_device_info_t *device_info =
-      rdm_pd_find(dmx_num, RDM_PID_DEVICE_INFO);
+  rdm_device_info_t *device_info =
+      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =
@@ -112,7 +112,8 @@ bool dmx_set_current_personality(dmx_port_t dmx_num, uint8_t personality_num) {
   // Get the required personality values from RDM device info or DMX driver
   uint8_t *current_personality;
   uint16_t *footprint;
-  rdm_device_info_t *device_info = rdm_pd_find(dmx_num, RDM_PID_DEVICE_INFO);
+  rdm_device_info_t *device_info =
+      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if (device_info == NULL) {
     dmx_driver_personality_t *personality = (void *)dmx_driver[dmx_num]->pd;
     current_personality = &personality->current_personality;
@@ -141,8 +142,8 @@ uint8_t dmx_get_personality_count(dmx_port_t dmx_num) {
   DMX_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
   DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
-  const rdm_device_info_t *device_info =
-      rdm_pd_find(dmx_num, RDM_PID_DEVICE_INFO);
+  rdm_device_info_t *device_info =
+      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =
         (void *)dmx_driver[dmx_num]->pd;
@@ -189,8 +190,8 @@ uint16_t dmx_get_start_address(dmx_port_t dmx_num) {
 
   uint16_t dmx_start_address;
 
-  const rdm_device_info_t *device_info =
-      rdm_pd_find(dmx_num, RDM_PID_DEVICE_INFO);
+  rdm_device_info_t *device_info =
+      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =

--- a/src/esp_dmx.c
+++ b/src/esp_dmx.c
@@ -88,7 +88,7 @@ uint8_t dmx_get_current_personality(dmx_port_t dmx_num) {
   uint8_t current_personality;
 
   rdm_device_info_t *device_info =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =
@@ -113,7 +113,7 @@ bool dmx_set_current_personality(dmx_port_t dmx_num, uint8_t personality_num) {
   uint8_t *current_personality;
   uint16_t *footprint;
   rdm_device_info_t *device_info =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if (device_info == NULL) {
     dmx_driver_personality_t *personality = (void *)dmx_driver[dmx_num]->pd;
     current_personality = &personality->current_personality;
@@ -143,7 +143,7 @@ uint8_t dmx_get_personality_count(dmx_port_t dmx_num) {
   DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
   rdm_device_info_t *device_info =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =
         (void *)dmx_driver[dmx_num]->pd;
@@ -191,7 +191,7 @@ uint16_t dmx_get_start_address(dmx_port_t dmx_num) {
   uint16_t dmx_start_address;
 
   rdm_device_info_t *device_info =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
   if (device_info == NULL) {
     const dmx_driver_personality_t *personality =

--- a/src/rdm/parameters.c
+++ b/src/rdm/parameters.c
@@ -42,7 +42,7 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, const uint8_t identify) {
   DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
   return rdm_set_parameter(dmx_num, RDM_PID_IDENTIFY_DEVICE, &identify,
-                           sizeof(identify), RDM_PARAMETER_FLAG_QUEUE);
+                           sizeof(identify), true);
 }
 
 bool rdm_get_dmx_start_address(dmx_port_t dmx_num,

--- a/src/rdm/parameters.c
+++ b/src/rdm/parameters.c
@@ -42,7 +42,7 @@ bool rdm_set_identify_device(dmx_port_t dmx_num, const uint8_t identify) {
   DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
 
   return rdm_set_parameter(dmx_num, RDM_PID_IDENTIFY_DEVICE, &identify,
-                           sizeof(identify), false);
+                           sizeof(identify), RDM_PARAMETER_FLAG_QUEUE);
 }
 
 bool rdm_get_dmx_start_address(dmx_port_t dmx_num,

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -8,9 +8,8 @@
 #include "endian.h"
 #include "rdm_utils.h"
 
-static int rdm_default_discovery_cb(dmx_port_t dmx_num,
-                                    const rdm_header_t *header, void *pd,
-                                    uint8_t *pdl_out, void *param,
+static int rdm_default_discovery_cb(dmx_port_t dmx_num, rdm_header_t *header,
+                                    void *pd, uint8_t *pdl_out, void *param,
                                     const rdm_pid_description_t *desc,
                                     const char *param_str) {
   // Return early if the sub-device is out of range
@@ -166,9 +165,8 @@ bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                 false);
 }
 
-static int rdm_simple_response_cb(dmx_port_t dmx_num,
-                                  const rdm_header_t *header, void *pd,
-                                  uint8_t *pdl_out, void *param,
+static int rdm_simple_response_cb(dmx_port_t dmx_num, rdm_header_t *header,
+                                  void *pd, uint8_t *pdl_out, void *param,
                                   const rdm_pid_description_t *desc,
                                   const char *param_str) {
   // Return early if the sub-device is out of range
@@ -187,11 +185,10 @@ static int rdm_simple_response_cb(dmx_port_t dmx_num,
 }
 
 static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
-                                            const rdm_header_t *header, void *pd,
+                                            rdm_header_t *header, void *pd,
                                             uint8_t *pdl_out, void *param,
                                             const rdm_pid_description_t *desc,
-                                            const char *param_str) 
-{
+                                            const char *param_str) {
   // Return early if the sub-device is out of range
   if (header->sub_device != RDM_SUB_DEVICE_ROOT) {
     *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_SUB_DEVICE_OUT_OF_RANGE);
@@ -219,12 +216,9 @@ static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
   return RDM_RESPONSE_TYPE_ACK;
 }
 
-static int rdm_personality_description_response_cb(dmx_port_t dmx_num,
-                                            const rdm_header_t *header, void *pd,
-                                            uint8_t *pdl_out, void *param,
-                                            const rdm_pid_description_t *desc,
-                                            const char *param_str) 
-{
+static int rdm_personality_description_response_cb(
+    dmx_port_t dmx_num, rdm_header_t *header, void *pd, uint8_t *pdl_out,
+    void *param, const rdm_pid_description_t *desc, const char *param_str) {
   if (header->sub_device != RDM_SUB_DEVICE_ROOT) {
     *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_SUB_DEVICE_OUT_OF_RANGE);
     return RDM_RESPONSE_TYPE_NACK_REASON;
@@ -269,12 +263,10 @@ static int rdm_personality_description_response_cb(dmx_port_t dmx_num,
 
   return RDM_RESPONSE_TYPE_ACK;
 }
-static int rdm_personality_response_cb(dmx_port_t dmx_num,
-                                            const rdm_header_t *header, void *pd,
-                                            uint8_t *pdl_out, void *param,
-                                            const rdm_pid_description_t *desc,
-                                            const char *param_str) 
-{
+static int rdm_personality_response_cb(dmx_port_t dmx_num, rdm_header_t *header,
+                                       void *pd, uint8_t *pdl_out, void *param,
+                                       const rdm_pid_description_t *desc,
+                                       const char *param_str) {
   // Return early if the sub-device is out of range
   if (header->sub_device != RDM_SUB_DEVICE_ROOT) {
     *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_SUB_DEVICE_OUT_OF_RANGE);
@@ -322,12 +314,9 @@ static int rdm_personality_response_cb(dmx_port_t dmx_num,
   }
 }
 
-static int rdm_parameter_description_response_cb(dmx_port_t dmx_num,
-                                                 const rdm_header_t *header, void *pd,
-                                                 uint8_t *pdl_out, void *param,
-                                                 const rdm_pid_description_t *desc,
-                                                 const char *param_str)
-{
+static int rdm_parameter_description_response_cb(
+    dmx_port_t dmx_num, rdm_header_t *header, void *pd, uint8_t *pdl_out,
+    void *param, const rdm_pid_description_t *desc, const char *param_str) {
   if (header->sub_device != RDM_SUB_DEVICE_ROOT)
   {
     *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_SUB_DEVICE_OUT_OF_RANGE);
@@ -363,7 +352,6 @@ static int rdm_parameter_description_response_cb(dmx_port_t dmx_num,
   *pdl_out = rdm_pd_emplace_word(pd, RDM_NR_DATA_OUT_OF_RANGE);
   return RDM_RESPONSE_TYPE_NACK_REASON;
 }
-
 
 bool rdm_register_device_info(dmx_port_t dmx_num,
                               rdm_device_info_t *device_info,

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -96,7 +96,8 @@ bool rdm_register_disc_unique_branch(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .description = "Discovery Unique Branch"};
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
-                                rdm_default_discovery_cb, NULL, cb, context);
+                                rdm_default_discovery_cb, NULL, cb, context,
+                                false);
 }
 
 bool rdm_register_disc_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
@@ -128,7 +129,8 @@ bool rdm_register_disc_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .description = "Discovery Mute"};
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
-                                rdm_default_discovery_cb, param, cb, context);
+                                rdm_default_discovery_cb, param, cb, context,
+                                false);
 }
 
 bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
@@ -160,7 +162,8 @@ bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .description = "Discovery Un-Mute"};
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
-                                rdm_default_discovery_cb, param, cb, context);
+                                rdm_default_discovery_cb, param, cb, context,
+                                false);
 }
 
 static int rdm_simple_response_cb(dmx_port_t dmx_num,
@@ -433,7 +436,8 @@ bool rdm_register_device_info(dmx_port_t dmx_num,
   const char *param_str = "#0100hwwdwbbwwb$";
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_simple_response_cb, param, cb, context);
+                                rdm_simple_response_cb, param, cb, context,
+                                false);
 }
 
 bool rdm_register_software_version_label(dmx_port_t dmx_num,
@@ -468,7 +472,8 @@ bool rdm_register_software_version_label(dmx_port_t dmx_num,
   }
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                  rdm_simple_response_cb, param, cb, context);
+                                rdm_simple_response_cb, param, cb, context,
+                                false);
 }
 
 bool rdm_register_device_label(dmx_port_t dmx_num,
@@ -503,7 +508,8 @@ bool rdm_register_device_label(dmx_port_t dmx_num,
   }
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_simple_response_cb, param, cb, context);
+                                rdm_simple_response_cb, param, cb, context,
+                                true);
 }
 
 bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
@@ -534,7 +540,8 @@ bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
   const char *param_str = "b$";
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_simple_response_cb, param, cb, context);
+                                rdm_simple_response_cb, param, cb, context,
+                                false);
 }
 
 
@@ -565,7 +572,8 @@ bool rdm_register_supported_parameters(dmx_port_t dmx_num, rdm_responder_cb_t cb
                                       .default_value = 0,
                                       .description = "Supported Parameters"};
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
-                                rdm_supported_params_response_cb, param, NULL, NULL);  
+                                rdm_supported_params_response_cb, param, NULL,
+                                NULL, false);
 }
 
 
@@ -600,7 +608,8 @@ bool rdm_register_dmx_personality(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                     .description = "DMX Personality"};
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, "b$",
-                                rdm_personality_response_cb, param, cb, context);  
+                                rdm_personality_response_cb, param, cb, context,
+                                false);
 }
 
 
@@ -625,11 +634,9 @@ bool rdm_register_dmx_personality_description(dmx_port_t dmx_num, rdm_responder_
                                     .default_value = 0, // has no meaning for RDM_DS_BIT_FIELD
                                     .description = "DMX Personality Description"};
 
-
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
-                                rdm_personality_description_response_cb, NULL, cb, context);  
-
-
+                                rdm_personality_description_response_cb, NULL,
+                                cb, context, false);
 }
 
 
@@ -656,7 +663,8 @@ bool rdm_register_dmx_start_address(dmx_port_t dmx_num, rdm_responder_cb_t cb,
   const char *param_str = "w$";
 
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_simple_response_cb, param, cb, context);
+                                rdm_simple_response_cb, param, cb, context,
+                                true);
 }
 
 bool rdm_register_parameter_description(dmx_port_t dmx_num, rdm_responder_cb_t cb,
@@ -676,16 +684,17 @@ bool rdm_register_parameter_description(dmx_port_t dmx_num, rdm_responder_cb_t c
                                       .default_value = 0,
                                       .description = "Parameter Description"};
 
-  const char *param_str = "wbbbbbbddda$";                                   
+  const char *param_str = "wbbbbbbddda$";
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_parameter_description_response_cb, NULL, NULL, NULL);
+                                rdm_parameter_description_response_cb, NULL,
+                                NULL, NULL, false);
 }
 
 bool rdm_register_manufacturer_specific_simple(dmx_port_t dmx_num, rdm_pid_description_t desc,
                                                void* param, const char *param_str, rdm_responder_cb_t cb,
-                                               void *context)
+                                               void *context, bool nvs)
 {
   return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
-                                rdm_simple_response_cb, param, cb, context);  
+                                rdm_simple_response_cb, param, cb, context, nvs);  
 }
 

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -22,7 +22,7 @@ static int rdm_default_discovery_cb(dmx_port_t dmx_num, rdm_header_t *header,
   if (header->pid == RDM_PID_DISC_UNIQUE_BRANCH) {
     // Ignore this message if discovery is muted
     const uint8_t *is_muted =
-        rdm_get_parameter(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
+        rdm_pd_get(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
     if (is_muted == NULL) {
       taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
       dmx_driver[dmx_num]->flags |= DMX_FLAGS_DRIVER_BOOT_LOADER;
@@ -95,7 +95,7 @@ bool rdm_register_disc_unique_branch(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .default_value = 0,
                                       .description = "Discovery Unique Branch"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
                                 rdm_default_discovery_cb, NULL, cb, context,
                                 false);
 }
@@ -106,10 +106,10 @@ bool rdm_register_disc_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
   DMX_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
   uint8_t *param =
-      rdm_get_parameter(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
     param =
-        rdm_get_parameter(dmx_num, RDM_PID_DISC_UN_MUTE, RDM_SUB_DEVICE_ROOT);
+        rdm_pd_get(dmx_num, RDM_PID_DISC_UN_MUTE, RDM_SUB_DEVICE_ROOT);
     if (param == NULL) {
       param = rdm_pd_alloc(dmx_num, sizeof(*param));
       if (param == NULL) {
@@ -130,7 +130,7 @@ bool rdm_register_disc_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .default_value = 0,
                                       .description = "Discovery Mute"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
                                 rdm_default_discovery_cb, param, cb, context,
                                 false);
 }
@@ -141,9 +141,9 @@ bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
   DMX_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
   uint8_t *param =
-      rdm_get_parameter(dmx_num, RDM_PID_DISC_UN_MUTE, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DISC_UN_MUTE, RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
-    param = rdm_get_parameter(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
+    param = rdm_pd_get(dmx_num, RDM_PID_DISC_MUTE, RDM_SUB_DEVICE_ROOT);
     if (param == NULL) {
       param = rdm_pd_alloc(dmx_num, sizeof(*param));
       if (param == NULL) {
@@ -164,7 +164,7 @@ bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .default_value = 0,
                                       .description = "Discovery Un-Mute"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
                                 rdm_default_discovery_cb, param, cb, context,
                                 false);
 }
@@ -197,7 +197,7 @@ static int rdm_personality_description_response_cb(
   }
 
   rdm_device_info_t *di =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, header->sub_device);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, header->sub_device);
   if(di == NULL)
   {
     //none of the error codes really fit, thus we just go with unknown pid
@@ -247,7 +247,7 @@ static int rdm_personality_response_cb(dmx_port_t dmx_num, rdm_header_t *header,
   }
 
   rdm_device_info_t *di =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if(di == NULL)
   {
     //none of the error codes really fit, thus we just go with unknown pid
@@ -334,7 +334,7 @@ bool rdm_register_device_info(dmx_port_t dmx_num,
   DMX_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
   rdm_device_info_t *param =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
     DMX_CHECK(device_info != NULL, false, "device_info is null");
     DMX_CHECK((device_info->dmx_start_address < DMX_PACKET_SIZE_MAX ||
@@ -398,7 +398,7 @@ bool rdm_register_device_info(dmx_port_t dmx_num,
                                       .description = "Device Info"};
   const char *param_str = "#0100hwwdwbbwwb$";
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context,
                                 false);
 }
@@ -421,7 +421,7 @@ bool rdm_register_software_version_label(dmx_port_t dmx_num,
                                       .description = "Software Version Label"};
   const char *param_str = "a$";
 
-  char *param = rdm_get_parameter(dmx_num, RDM_PID_SOFTWARE_VERSION_LABEL,
+  char *param = rdm_pd_get(dmx_num, RDM_PID_SOFTWARE_VERSION_LABEL,
                                   RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
     DMX_CHECK(software_version_label != NULL, false,
@@ -435,7 +435,7 @@ bool rdm_register_software_version_label(dmx_port_t dmx_num,
     strncpy(param, software_version_label, 32);
   }
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context,
                                 false);
 }
@@ -459,7 +459,7 @@ bool rdm_register_device_label(dmx_port_t dmx_num,
   const char *param_str = "a$";
 
   char *param =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_LABEL, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_LABEL, RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
     DMX_CHECK(device_label != NULL, false,
               "device_label is null");
@@ -472,7 +472,7 @@ bool rdm_register_device_label(dmx_port_t dmx_num,
     strncpy(param, device_label, 32);
   }
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context,
                                 true);
 }
@@ -484,7 +484,7 @@ bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
   DMX_CHECK(dmx_driver_is_installed(dmx_num), false, "driver is not installed");
 
   uint8_t *param =
-      rdm_get_parameter(dmx_num, RDM_PID_IDENTIFY_DEVICE, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_IDENTIFY_DEVICE, RDM_SUB_DEVICE_ROOT);
   if (param == NULL) {
     param = rdm_pd_alloc(dmx_num, sizeof(*param));
     if (param == NULL) {
@@ -505,7 +505,7 @@ bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .description = "Identify Device"};
   const char *param_str = "b$";
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context,
                                 false);
 }
@@ -550,7 +550,7 @@ bool rdm_register_dmx_personality(dmx_port_t dmx_num, rdm_responder_cb_t cb,
 
   // Current personality is stored within device info
   rdm_device_info_t *di =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   DMX_CHECK(di != NULL, false, "RDM_PID_DEVICE_INFO must be registered first");
 
   // Note: The personality is a strange parameter that needs a custom callback
@@ -574,7 +574,7 @@ bool rdm_register_dmx_personality(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                     .default_value = 1, 
                                     .description = "DMX Personality"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, "b$",
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, "b$",
                                 rdm_personality_response_cb, param, cb, context,
                                 false);
 }
@@ -588,7 +588,7 @@ bool rdm_register_dmx_personality_description(dmx_port_t dmx_num, rdm_responder_
 
   // Personality is stored within device info
   rdm_device_info_t *di =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   DMX_CHECK(di != NULL, false, "RDM_PID_DEVICE_INFO must be registered first");
 
   const rdm_pid_description_t desc = {.pid = RDM_PID_DMX_PERSONALITY_DESCRIPTION,
@@ -602,7 +602,7 @@ bool rdm_register_dmx_personality_description(dmx_port_t dmx_num, rdm_responder_
                                     .default_value = 0, // has no meaning for RDM_DS_BIT_FIELD
                                     .description = "DMX Personality Description"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
                                 rdm_personality_description_response_cb, NULL,
                                 cb, context, false);
 }
@@ -615,7 +615,7 @@ bool rdm_register_dmx_start_address(dmx_port_t dmx_num, rdm_responder_cb_t cb,
 
   // DMX start address is stored within device info
   rdm_device_info_t *di =
-      rdm_get_parameter(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
+      rdm_pd_get(dmx_num, RDM_PID_DEVICE_INFO, RDM_SUB_DEVICE_ROOT);
   DMX_CHECK(di != NULL, false, "RDM_PID_DEVICE_INFO must be registered first");
   uint16_t *param = (void *)di + offsetof(rdm_device_info_t, dmx_start_address);
 
@@ -631,7 +631,7 @@ bool rdm_register_dmx_start_address(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .description = "DMX Start Address"};
   const char *param_str = "w$";
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context,
                                 true);
 }
@@ -654,7 +654,7 @@ bool rdm_register_parameter_description(dmx_port_t dmx_num, rdm_responder_cb_t c
                                       .description = "Parameter Description"};
 
   const char *param_str = "wbbbbbbddda$";
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_parameter_description_response_cb, NULL,
                                 NULL, NULL, false);
 }
@@ -663,7 +663,7 @@ bool rdm_register_manufacturer_specific_simple(dmx_port_t dmx_num, rdm_pid_descr
                                                void* param, const char *param_str, rdm_responder_cb_t cb,
                                                void *context, bool nvs)
 {
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, param_str,
                                 rdm_simple_response_cb, param, cb, context, nvs);  
 }
 
@@ -742,7 +742,7 @@ bool rdm_register_queued_message(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                       .default_value = 0,
                                       .description = "Queued Message"};
 
-  return rdm_register_parameter(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
+  return rdm_pd_register(dmx_num, RDM_SUB_DEVICE_ROOT, &desc, NULL,
                                 rdm_queued_message_response_cb, NULL, cb,
                                 context, false);
 }

--- a/src/rdm/responder.c
+++ b/src/rdm/responder.c
@@ -170,7 +170,7 @@ bool rdm_register_disc_un_mute(dmx_port_t dmx_num, rdm_responder_cb_t cb,
 }
 
 static int rdm_simple_response_cb(dmx_port_t dmx_num, rdm_header_t *header,
-                                  void *pd, uint8_t *pdl_out, void *param,
+                                  void *pd, uint8_t *pdl_out,
                                   const rdm_pid_description_t *desc,
                                   const char *param_str) {
   // Return early if the sub-device is out of range
@@ -179,6 +179,7 @@ static int rdm_simple_response_cb(dmx_port_t dmx_num, rdm_header_t *header,
     return RDM_RESPONSE_TYPE_NACK_REASON;
   }
 
+  void *param = rdm_pd_get(dmx_num, header->pid, header->sub_device);
   if (header->cc == RDM_CC_GET_COMMAND) {
     *pdl_out = rdm_pd_emplace(pd, param_str, param, desc->pdl_size, false);
   } else {
@@ -512,7 +513,7 @@ bool rdm_register_identify_device(dmx_port_t dmx_num, rdm_responder_cb_t cb,
 
 static int rdm_supported_params_response_cb(dmx_port_t dmx_num,
                                             rdm_header_t *header, void *pd,
-                                            uint8_t *pdl_out, void *param,
+                                            uint8_t *pdl_out,
                                             const rdm_pid_description_t *desc,
                                             const char *param_str) {
   // Return early if the sub-device is out of range
@@ -697,7 +698,7 @@ bool rdm_register_manufacturer_specific_simple(dmx_port_t dmx_num, rdm_pid_descr
 
 static int rdm_status_messages_response_cb(dmx_port_t dmx_num,
                                            rdm_header_t *header, void *pd,
-                                           uint8_t *pdl_out, void *param,
+                                           uint8_t *pdl_out,
                                            const rdm_pid_description_t *desc,
                                            const char *param_str) {
   // TODO: error checking
@@ -714,7 +715,7 @@ static int rdm_status_messages_response_cb(dmx_port_t dmx_num,
 
 static int rdm_queued_message_response_cb(dmx_port_t dmx_num,
                                           rdm_header_t *header, void *pd,
-                                          uint8_t *pdl_out, void *param,
+                                          uint8_t *pdl_out,
                                           const rdm_pid_description_t *desc,
                                           const char *param_str) {
   // Verify data is valid
@@ -747,8 +748,8 @@ static int rdm_queued_message_response_cb(dmx_port_t dmx_num,
   } else {
     // When there aren't any queued messages respond with a status message
     header->pid = RDM_PID_STATUS_MESSAGE;
-    ack = rdm_status_messages_response_cb(dmx_num, header, pd, pdl_out, param,
-                                          desc, param_str);
+    ack = rdm_status_messages_response_cb(dmx_num, header, pd, pdl_out, desc,
+                                          param_str);
   }
 
   return ack;

--- a/src/rdm/responder.h
+++ b/src/rdm/responder.h
@@ -153,10 +153,10 @@ bool rdm_register_supported_parameters(dmx_port_t dmx_num, rdm_responder_cb_t cb
 bool rdm_register_parameter_description(dmx_port_t dmx_num, rdm_responder_cb_t cb,
                                         void *context);
 
-bool rdm_register_manufacturer_specific_simple(dmx_port_t dmx_num, rdm_pid_description_t desc,
-                                               void* param, const char *param_str,
-                                               rdm_responder_cb_t cb, void *context);
-                                        
+// TODO: docs
+bool rdm_register_manufacturer_specific_simple(
+    dmx_port_t dmx_num, rdm_pid_description_t desc, void *param,
+    const char *param_str, rdm_responder_cb_t cb, void *context, bool nvs);
 
 /**
  * @brief Registers the default response to RDM_PID_DMX_START_ADDRESS requests.

--- a/src/rdm_types.h
+++ b/src/rdm_types.h
@@ -417,6 +417,9 @@ typedef struct rdm_ack_t {
   size_t size;
   /** @brief The UID of the device originating the response packet.*/
   rdm_uid_t src_uid;
+  /** @brief The PID of the response packet. It is typically the same PID as the
+   * RDM request. */
+  rdm_pid_t pid;
   /** @brief The type of the RDM response received.*/
   rdm_response_type_t type;
   /** @brief The message count field is used by a responder to indicate that

--- a/src/rdm_types.h
+++ b/src/rdm_types.h
@@ -639,6 +639,20 @@ typedef struct __attribute__((packed)) rdm_dmx_personality_t {
   uint8_t personality_count;
 } rdm_dmx_personality_t;
 
+// TODO: docs
+typedef struct __attribute__((packed)) rdm_status_message_t {
+   uint16_t sub_device;
+   uint8_t type;
+   uint16_t id;
+   union {
+      struct {
+         uint16_t data1;
+         uint16_t data2;
+      };
+      uint16_t data[2];
+   };
+} rdm_status_message_t;
+
 /** @brief UID which indicates an RDM packet is being broadcast to all devices
  * regardless of manufacturer. Responders shall not respond to RDM broadcast
  * messages.*/

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -396,30 +396,13 @@ bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
 
   // Handle NVS and RDM queueing
   if (ret) {
-    // TODO: remove this part 
-    const uint16_t nvs_pids[] = {
-        RDM_PID_DEVICE_LABEL,    RDM_PID_LANGUAGE,
-        RDM_PID_DMX_PERSONALITY, RDM_PID_DMX_START_ADDRESS,
-        RDM_PID_DEVICE_HOURS,    RDM_PID_LAMP_HOURS,
-        RDM_PID_LAMP_STRIKES,    RDM_PID_LAMP_STATE,
-        RDM_PID_LAMP_ON_MODE,    RDM_PID_DEVICE_POWER_CYCLES,
-        RDM_PID_DISPLAY_INVERT,  RDM_PID_DISPLAY_LEVEL,
-        RDM_PID_PAN_INVERT,      RDM_PID_TILT_INVERT,
-        RDM_PID_PAN_TILT_SWAP};
-    for (int i = 0; i < sizeof(nvs_pids) / sizeof(uint16_t); ++i) {
-      if (nvs_pids[i] == pid) {
-        save_to_nvs = true;
-        break;
-      }
-    }
-
     // Save to NVS if needed
     if (save_to_nvs) {
       if (!dmx_nvs_set(dmx_num, pid, desc->data_type, param, size)) {
         taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
         driver->flags |= DMX_FLAGS_DRIVER_BOOT_LOADER;
         taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
-        DMX_ERR("unable to write to NVS");
+        DMX_WARN("unable to save PID 0x%04x to NVS", pid)
       }
     }
 

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -255,6 +255,35 @@ bool rdm_pd_register(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
   return true;
 }
 
+uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
+                     uint16_t *pids, uint32_t num) {
+  assert(dmx_num < DMX_NUM_MAX);
+  assert(dmx_driver_is_installed(dmx_num));
+
+  // TODO
+  DMX_CHECK(sub_device == RDM_SUB_DEVICE_ROOT, 0,
+            "Multiple sub-devices are not yet supported.");
+
+  // Stop writes to a null pointer array
+  if (pids == NULL) {
+    num = 0;
+  }
+
+  dmx_driver_t *const driver = dmx_driver[dmx_num];
+
+  // Copy the PIDs into the buffer
+  uint32_t num_pids = 0;
+  taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
+  for (; num_pids < driver->num_rdm_cbs; ++num_pids) {
+    if (num_pids < num) {
+      pids[num_pids] = driver->rdm_cbs->desc.pid;
+    }
+  }
+  taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
+
+  return num_pids;
+}
+
 void *rdm_pd_get(dmx_port_t dmx_num, rdm_pid_t pid,
                         rdm_sub_device_t sub_device) {
   dmx_driver_t *const driver = dmx_driver[dmx_num];
@@ -490,33 +519,4 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
   // Give the mutex back
   xSemaphoreGiveRecursive(driver->mux);
   return (response_type == RDM_RESPONSE_TYPE_ACK);
-}
-
-uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
-                     uint16_t *pids, uint32_t num) {
-  assert(dmx_num < DMX_NUM_MAX);
-  assert(dmx_driver_is_installed(dmx_num));
-
-  // TODO
-  DMX_CHECK(sub_device == RDM_SUB_DEVICE_ROOT, 0,
-            "Multiple sub-devices are not yet supported.");
-
-  // Stop writes to a null pointer array
-  if (pids == NULL) {
-    num = 0;
-  }
-
-  dmx_driver_t *const driver = dmx_driver[dmx_num];
-
-  // Copy the PIDs into the buffer
-  uint32_t num_pids = 0;
-  taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
-  for (; num_pids < driver->num_rdm_cbs; ++num_pids) {
-    if (num_pids < num) {
-      pids[num_pids] = driver->rdm_cbs->desc.pid;
-    }
-  }
-  taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
-
-  return num_pids;
 }

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -453,7 +453,7 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
   taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
   header->tn = driver->tn;
   taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
-  header->message_count = 0;
+  header->message_count = 0;  // Required for all controller requests
 
   // Determine if a response is expected
   const bool response_expected = !rdm_uid_is_broadcast(&header->dest_uid) ||

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -246,7 +246,7 @@ bool rdm_pd_register(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
   driver->rdm_cbs[i].user_cb = user_cb;
   driver->rdm_cbs[i].driver_cb = driver_cb;
   driver->rdm_cbs[i].desc = *desc;
-  driver->rdm_cbs[i].nvs = nvs;
+  driver->rdm_cbs[i].non_volatile = nvs;
   const bool added_cb = (i == driver->num_rdm_cbs);
   if (added_cb) {
     ++driver->num_rdm_cbs;
@@ -291,7 +291,7 @@ bool rdm_pd_set(dmx_port_t dmx_num, rdm_pid_t pid,
     if (driver->rdm_cbs[i].desc.pid == pid) {
       pd = driver->rdm_cbs[i].param;
       desc = &driver->rdm_cbs[i].desc;
-      save_to_nvs = driver->rdm_cbs[i].nvs;
+      save_to_nvs = driver->rdm_cbs[i].non_volatile;
       break;
     }
   }

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -519,3 +519,32 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
   xSemaphoreGiveRecursive(driver->mux);
   return (response_type == RDM_RESPONSE_TYPE_ACK);
 }
+
+uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
+                     uint16_t *pids, uint32_t num) {
+  assert(dmx_num < DMX_NUM_MAX);
+  assert(dmx_driver_is_installed(dmx_num));
+
+  // TODO
+  DMX_CHECK(sub_device == RDM_SUB_DEVICE_ROOT, 0,
+            "Multiple sub-devices are not yet supported.");
+
+  // Stop writes to a null pointer array
+  if (pids == NULL) {
+    num = 0;
+  }
+
+  dmx_driver_t *const driver = dmx_driver[dmx_num];
+
+  // Copy the PIDs into the buffer
+  uint32_t num_pids = 0;
+  taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
+  for (; num_pids < driver->num_rdm_cbs; ++num_pids) {
+    if (num_pids < num) {
+      pids[num_pids] = driver->rdm_cbs->desc.pid;
+    }
+  }
+  taskEXIT_CRITICAL(DMX_SPINLOCK(dmx_num));
+
+  return num_pids;
+}

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -46,7 +46,7 @@ void rdm_uid_get_binding(rdm_uid_t *uid) {
   rdm_uid_get(rdm_binding_port, uid);
 }
 
-static size_t rdm_param_parse(const char *format) {
+static size_t rdm_pd_parse(const char *format) {
   int param_size = 0;
   for (const char *f = format; *f != '\0'; ++f) {
     size_t field_size = 0;
@@ -104,7 +104,7 @@ size_t rdm_pd_emplace(void *destination, const char *format, const void *source,
   }
 
   // Ensure that the format string syntax is correct
-  const int param_size = rdm_param_parse(format);
+  const int param_size = rdm_pd_parse(format);
   if (param_size == 0) {
     return 0;
   }

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -493,6 +493,7 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
         ack->src_uid = (rdm_uid_t){0, 0};
         ack->message_count = 0;
         ack->type = RDM_RESPONSE_TYPE_INVALID;
+        ack->pid = 0;
       }
       xSemaphoreGiveRecursive(driver->mux);
       return false;
@@ -502,6 +503,7 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
         ack->src_uid = (rdm_uid_t){0, 0};
         ack->message_count = 0;
         ack->type = RDM_RESPONSE_TYPE_NONE;
+        ack->pid = 0;
       }
       xSemaphoreGiveRecursive(driver->mux);
       return false;
@@ -513,6 +515,7 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
       ack->src_uid = (rdm_uid_t){0, 0};
       ack->message_count = 0;
       ack->type = RDM_RESPONSE_TYPE_NONE;
+      ack->pid = 0;
     }
     dmx_wait_sent(dmx_num, 2);
     xSemaphoreGiveRecursive(driver->mux);
@@ -565,6 +568,7 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
     ack->src_uid = resp.src_uid;
     ack->message_count = resp.message_count;
     ack->timer = decoded;
+    ack->pid = resp.pid;
   }
 
   // Give the mutex back

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -326,7 +326,7 @@ bool rdm_pd_set(dmx_port_t dmx_num, rdm_pid_t pid,
     if (add_to_queue) {
       bool success; 
       taskENTER_CRITICAL(DMX_SPINLOCK(dmx_num));
-      if (driver->rdm_queue_size < RDM_RESPONDER_MAX_QUEUE_SIZE) {
+      if (driver->rdm_queue_size < RDM_RESPONDER_QUEUE_SIZE_MAX) {
         driver->rdm_queue[driver->rdm_queue_size] = pid;
         ++driver->rdm_queue_size;
         success = true;

--- a/src/rdm_utils.c
+++ b/src/rdm_utils.c
@@ -247,39 +247,11 @@ bool rdm_pd_register(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
   driver->rdm_cbs[i].driver_cb = driver_cb;
   driver->rdm_cbs[i].desc = *desc;
   driver->rdm_cbs[i].nvs = nvs;
-
-  bool newCallback = i == driver->num_rdm_cbs;
-
-  if(newCallback) 
-  {
-    // If this parameter lies outside the minimum required parameter set, we
-    // need to put it into the supported_parameters list to let rdm masters know
-    // about it.
-    switch(desc->pid)
-    {
-      // minimum required parameters
-      case RDM_PID_DISC_UNIQUE_BRANCH:
-      case RDM_PID_DISC_MUTE:
-      case RDM_PID_DISC_UN_MUTE:
-      case RDM_PID_SUPPORTED_PARAMETERS:
-      case RDM_PID_PARAMETER_DESCRIPTION:
-      case RDM_PID_DEVICE_INFO:
-      case RDM_PID_SOFTWARE_VERSION_LABEL:
-      case RDM_PID_DMX_START_ADDRESS:
-      case RDM_PID_IDENTIFY_DEVICE:
-        break;
-      default:
-        if(!rdm_add_supported_parameter(dmx_num, desc->pid))
-        {
-          ESP_LOGE(TAG, "Failed to add parmeter %d to parmeter list.", desc->pid);
-        }
-    }
-  }
-
-  if(newCallback)
-  {
+  const bool added_cb = (i == driver->num_rdm_cbs);
+  if (added_cb) {
     ++driver->num_rdm_cbs;
   }
+
   return true;
 }
 

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -193,7 +193,7 @@ static inline bool DMX_ISR_ATTR rdm_uid_is_target(const rdm_uid_t *uid,
  * ensure it is formatted correctly for the RDM data bus or for the ESP32's
  * memory. Emplacing data swaps the endianness of each parameter field and also
  * optionally writes null terminators for strings and writes optional UID
- * fields.
+ * fields. The destination buffer and the source buffer may overlap.
  *
  * Parameter fields are emplaced using a format string. This provides the
  * instructions on how data is written. Fields are written in the order provided

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -363,6 +363,9 @@ bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
  * - ack.size is the size of the received RDM packet, including the RDM
  *   checksum.
  * - ack.src_uid is the UID of the device which responds to the request.
+ * - ack.pid is the PID of the RDM response packet. This is typically the same
+ *   as the PID which was sent in the RDM request, but may be a different value
+ *   in certain responses.
  * - ack.type will evaluate to RDM_RESPONSE_TYPE_INVALID if an invalid
  *   response is received but does not necessarily indicate a DMX error
  *   occurred. If no response is received ack.type will be set to
@@ -382,7 +385,7 @@ bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
  * request.
  * @param[in] pd_in A pointer which stores parameter data to be written.
  * @param[out] pd_out A pointer which stores parameter data which was read, if a
- * response was received.
+ * response was received. This can be an alias of pd_in.
  * @param[inout] pdl The size of the pd_out buffer. When receiving data, this is
  * set to the PDL of the received data. Used to prevent buffer overflows.
  * @param[out] ack A pointer to an rdm_ack_t which stores information about the

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -280,15 +280,6 @@ size_t rdm_pd_emplace_word(void *destination, uint16_t word);
 void *rdm_pd_alloc(dmx_port_t dmx_num, size_t size);
 
 /**
- * @brief Finds the pointer to the parameter data for a registered parameter.
- *
- * @param dmx_num The DMX port number.
- * @param pid The parameter ID to find.
- * @return A pointer to the parameter data or NULL on failure.
- */
-void *rdm_pd_find(dmx_port_t dmx_num, rdm_pid_t pid);
-
-/**
  * @brief Registers a response callback to be called when a request is received
  * for a specified PID for this device. Callbacks may be overwritten, but they
  * may not be deleted. The pointers to the parameter and context are copied by
@@ -312,11 +303,10 @@ void *rdm_pd_find(dmx_port_t dmx_num, rdm_pid_t pid);
  * @return true if the response was successfully registered.
  * @return false if the response was not registered.
  */
-bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
-                            const rdm_pid_description_t *desc,
-                            const char *param_str, rdm_driver_cb_t driver_cb,
-                            void *param, rdm_responder_cb_t user_cb,
-                            void *context, bool nvs);
+bool rdm_pd_register(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
+                     const rdm_pid_description_t *desc, const char *param_str,
+                     rdm_driver_cb_t driver_cb, void *param,
+                     rdm_responder_cb_t user_cb, void *context, bool nvs);
 
 /**
  * @brief Gets a pointer to the parameter stored in the RDM device, if the
@@ -325,7 +315,7 @@ bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
  * @note This function returns a pointer to the raw parameter data which is
  * stored on the RDM device. It is possible to edit the data directly but this
  * is not recommended for most use cases. The proper way to update RDM parameter
- * data would be to use the function `rdm_set_parameter()` because it properly
+ * data would be to use the function `rdm_pd_set()` because it properly
  * updates NVS and the RDM queue.
  *
  * @param dmx_num The DMX port number.
@@ -334,8 +324,8 @@ bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
  * @return A pointer to the parameter data or NULL if the parameter does not
  * exist.
  */
-void *rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid,
-                        rdm_sub_device_t sub_device);
+void *rdm_pd_get(dmx_port_t dmx_num, rdm_pid_t pid,
+                 rdm_sub_device_t sub_device);
 
 /**
  * @brief Sets the value of a specified RDM parameter. This function will not
@@ -351,9 +341,8 @@ void *rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid,
  * @return true on success.
  * @return false on failure.
  */
-bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid,
-                       rdm_sub_device_t sub_device, const void *param,
-                       size_t size, bool add_to_queue);
+bool rdm_pd_set(dmx_port_t dmx_num, rdm_pid_t pid, rdm_sub_device_t sub_device,
+                const void *param, size_t size, bool add_to_queue);
 
 /**
  * @brief Sends an RDM controller request and processes the response. This

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief A function type for RDM responder callbacks. This is the type of
  * function that is called when responding to RDM requests.
  */
-typedef int (*rdm_driver_cb_t)(dmx_port_t dmx_num, const rdm_header_t *header,
+typedef int (*rdm_driver_cb_t)(dmx_port_t dmx_num, rdm_header_t *header,
                                void *pd, uint8_t *pdl_out, void *param,
                                const rdm_pid_description_t *desc,
                                const char *param_str);

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -392,6 +392,10 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
                       const void *pd_in, void *pd_out, size_t *pdl,
                       rdm_ack_t *ack);
 
+// TODO docs
+uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
+                     uint16_t *pids, uint32_t num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -319,34 +319,40 @@ bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
                             void *context, bool nvs);
 
 /**
- * @brief Copies a specified RDM parameter to a buffer.
+ * @brief Gets a pointer to the parameter stored in the RDM device, if the
+ * parameter exists.
+ *
+ * @note This function returns a pointer to the raw parameter data which is
+ * stored on the RDM device. It is possible to edit the data directly but this
+ * is not recommended for most use cases. The proper way to update RDM parameter
+ * data would be to use the function `rdm_set_parameter()` because it properly
+ * updates NVS and the RDM queue.
  *
  * @param dmx_num The DMX port number.
  * @param pid The parameter ID to get.
- * @param[out] param A pointer to a buffer into which to copy the parameter
- * data.
- * @param[inout] size The size of the parameter data. Upon getting the parameter
- * data, this value is set to the size of the parameter.
- * @return true on success.
- * @return false on failure.
+ * @param sub_device The sub-device number which owns the parameter.
+ * @return A pointer to the parameter data or NULL if the parameter does not
+ * exist.
  */
-bool rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid, void *param,
-                       size_t *size);
+void *rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid,
+                        rdm_sub_device_t sub_device);
 
 /**
- * @brief Sets the value of a specified RDM parameter. This function will set
- * the value of an RDM parameter even if the parameter does not support SET
+ * @brief Sets the value of a specified RDM parameter. This function will not
+ * set the value of an RDM parameter if the parameter does not support SET
  * requests.
  *
  * @param dmx_num The DMX port number.
  * @param pid The parameter ID to set.
+ * @param sub_device The sub-device number which owns the parameter.
  * @param[in] param A pointer to the new value to which to set the parameter.
  * @param size The size of the new value of the parameter.
  * @param add_to_queue True to add this parameter to the RDM message queue.
  * @return true on success.
  * @return false on failure.
  */
-bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
+bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid,
+                       rdm_sub_device_t sub_device, const void *param,
                        size_t size, bool add_to_queue);
 
 /**

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -342,7 +342,7 @@ bool rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid, void *param,
  * @param pid The parameter ID to set.
  * @param[in] param A pointer to the new value to which to set the parameter.
  * @param size The size of the new value of the parameter.
- * @param add_to_queue // TODO
+ * @param add_to_queue True to add this parameter to the RDM message queue.
  * @return true on success.
  * @return false on failure.
  */

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -308,6 +308,10 @@ bool rdm_pd_register(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
                      rdm_driver_cb_t driver_cb, void *param,
                      rdm_responder_cb_t user_cb, void *context, bool nvs);
 
+// TODO docs
+uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
+                     uint16_t *pids, uint32_t num);
+
 /**
  * @brief Gets a pointer to the parameter stored in the RDM device, if the
  * parameter exists.
@@ -392,9 +396,6 @@ bool rdm_send_request(dmx_port_t dmx_num, rdm_header_t *header,
                       const void *pd_in, void *pd_out, size_t *pdl,
                       rdm_ack_t *ack);
 
-// TODO docs
-uint32_t rdm_pd_list(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
-                     uint16_t *pids, uint32_t num);
 
 #ifdef __cplusplus
 }

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -23,6 +23,11 @@
 extern "C" {
 #endif
 
+enum dmx_parameter_flag_t {
+  RDM_PARAMETER_FLAG_NVS = BIT0,
+  RDM_PARAMETER_FLAG_QUEUE = BIT1,
+};
+
 /**
  * @brief A function type for RDM responder callbacks. This is the type of
  * function that is called when responding to RDM requests.
@@ -341,12 +346,12 @@ bool rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid, void *param,
  * @param pid The parameter ID to set.
  * @param[in] param A pointer to the new value to which to set the parameter.
  * @param size The size of the new value of the parameter.
- * @param nvs Set to true if this parameter should also be updated in NVS.
+ * @param flags // TODO
  * @return true on success.
  * @return false on failure.
  */
 bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
-                       size_t size, bool nvs);
+                       size_t size, int flags);
 
 /**
  * @brief Sends an RDM controller request and processes the response. This

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -28,9 +28,7 @@ extern "C" {
  * function that is called when responding to RDM requests.
  */
 typedef int (*rdm_driver_cb_t)(dmx_port_t dmx_num, rdm_header_t *header,
-                               void *pd, uint8_t *pdl_out,
-                               const rdm_pid_description_t *desc,
-                               const char *param_str);
+                               void *pd, uint8_t *pdl, const char *param_str);
 
 /**
  * @brief Copies RDM UID from a source buffer directly into a destination

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -23,11 +23,6 @@
 extern "C" {
 #endif
 
-enum dmx_parameter_flag_t {
-  RDM_PARAMETER_FLAG_NVS = BIT0,
-  RDM_PARAMETER_FLAG_QUEUE = BIT1,
-};
-
 /**
  * @brief A function type for RDM responder callbacks. This is the type of
  * function that is called when responding to RDM requests.
@@ -313,6 +308,7 @@ void *rdm_pd_find(dmx_port_t dmx_num, rdm_pid_t pid);
  * @param user_cb A user-side callback function which is called after a request
  * for this PID is handled.
  * @param[in] context A pointer to a user-defined context.
+ * @param nvs True if this parameter should be saved to non-volatile memory.
  * @return true if the response was successfully registered.
  * @return false if the response was not registered.
  */
@@ -320,7 +316,7 @@ bool rdm_register_parameter(dmx_port_t dmx_num, rdm_sub_device_t sub_device,
                             const rdm_pid_description_t *desc,
                             const char *param_str, rdm_driver_cb_t driver_cb,
                             void *param, rdm_responder_cb_t user_cb,
-                            void *context);
+                            void *context, bool nvs);
 
 /**
  * @brief Copies a specified RDM parameter to a buffer.
@@ -346,12 +342,12 @@ bool rdm_get_parameter(dmx_port_t dmx_num, rdm_pid_t pid, void *param,
  * @param pid The parameter ID to set.
  * @param[in] param A pointer to the new value to which to set the parameter.
  * @param size The size of the new value of the parameter.
- * @param flags // TODO
+ * @param add_to_queue // TODO
  * @return true on success.
  * @return false on failure.
  */
 bool rdm_set_parameter(dmx_port_t dmx_num, rdm_pid_t pid, const void *param,
-                       size_t size, int flags);
+                       size_t size, bool add_to_queue);
 
 /**
  * @brief Sends an RDM controller request and processes the response. This

--- a/src/rdm_utils.h
+++ b/src/rdm_utils.h
@@ -28,7 +28,7 @@ extern "C" {
  * function that is called when responding to RDM requests.
  */
 typedef int (*rdm_driver_cb_t)(dmx_port_t dmx_num, rdm_header_t *header,
-                               void *pd, uint8_t *pdl_out, void *param,
+                               void *pd, uint8_t *pdl_out,
                                const rdm_pid_description_t *desc,
                                const char *param_str);
 


### PR DESCRIPTION
This PR adds the RDM queue feature of RDM. It allows the RDM driver to save queued messages for retrieval by RDM controllers.

Support of queued messages are important to allow for better communication between the RDM responder and the RDM controller. If, for example, a technician manually changes the DMX address of an RDM responder without sending a SET RDM_PID_DMX_START_ADDRESS request (i.e., the technician uses the RDM responder's DIP switches), the RDM controller will have no way to know that the responder's DMX address was updated. 

With RDM queued messages, when the RDM responder's DMX start address is manually updated a RDM message is placed in the responder's message queue. The RDM controller can see that the responder queued a message. The controller will read the queued message and see that the DMX start address was updated.

This PR is created as a draft to allow for discussion.