### PR TITLE
Fix Arduino Compilation Error

### DIFF
--- a/src/dmx/hal/timer.c
+++ b/src/dmx/hal/timer.c
@@ -94,7 +94,7 @@ bool dmx_timer_init(dmx_port_t dmx_num, void *isr_context, int isr_flags) {
   if (err) {
     return NULL;
   }
-  timer_isr_callback_add(timer->group, timer->idx, isr_handle, isr_context,
+  timer_isr_callback_add(timer->group, timer->idx, dmx_timer_isr, isr_context,
                          isr_flags);
 #endif
   timer->is_running = false;


### PR DESCRIPTION
This changes the ISR vector used in the hardware timer interrupt to the correct value. This compilation error appeared on devices using ESP-IDF version 4 or lesser.