### PR TITLE
Fix for #150

### DIFF
--- a/src/dmx/hal/uart.c
+++ b/src/dmx/hal/uart.c
@@ -29,7 +29,7 @@ static struct dmx_uart_t {
 } dmx_uart_context[DMX_NUM_MAX] = {
     {.num = 0, .dev = UART_LL_GET_HW(0)},
     {.num = 1, .dev = UART_LL_GET_HW(1)},
-#if DMX_NUM_MAX > 2
+#if SOC_UART_NUM > 2
     {.num = 2, .dev = UART_LL_GET_HW(2)},
 #endif
 };


### PR DESCRIPTION
As per fix by [GIPdA](https://github.com/GIPdA) : Currently DMX_NUM_MAX is used, but it's an enum and cannot be used in pre-processor.