### PR TITLE
Support ESP-IDF Install from External Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,33 @@
+# If the ESP_DMX_ROOT variable is not set, set it to the current directory
+if(NOT DEFINED ESP_DMX_ROOT)
+  set(ESP_DMX_ROOT ".")
+endif()
+
 idf_component_register(
   SRCS 
        # DMX driver HAL
-       "src/dmx/hal/uart.c" "src/dmx/hal/timer.c" "src/dmx/hal/nvs.c"
-       "src/dmx/hal/gpio.c"
+       "${ESP_DMX_ROOT}/src/dmx/hal/uart.c" "${ESP_DMX_ROOT}/src/dmx/hal/timer.c" "${ESP_DMX_ROOT}/src/dmx/hal/nvs.c"
+       "${ESP_DMX_ROOT}/src/dmx/hal/gpio.c"
        
        # DMX driver and sniffer
-       "src/dmx/service.c" "src/dmx/driver.c"
-       "src/dmx/io.c" "src/dmx/device.c" "src/dmx/parameter.c"
-       "src/dmx/sniffer.c" 
+       "${ESP_DMX_ROOT}/src/dmx/service.c" "${ESP_DMX_ROOT}/src/dmx/driver.c"
+       "${ESP_DMX_ROOT}/src/dmx/io.c" "${ESP_DMX_ROOT}/src/dmx/device.c" "${ESP_DMX_ROOT}/src/dmx/parameter.c"
+       "${ESP_DMX_ROOT}/src/dmx/sniffer.c" 
 
        # RDM driver
-       "src/rdm/driver.c"
+       "${ESP_DMX_ROOT}/src/rdm/driver.c"
        
        # RDM controller
-       "src/rdm/controller/discovery.c" "src/rdm/controller/product_info.c"
-       "src/rdm/controller/device_control.c" "src/rdm/controller/dmx_setup.c"
-       "src/rdm/controller/utils.c"
+       "${ESP_DMX_ROOT}/src/rdm/controller/discovery.c" "${ESP_DMX_ROOT}/src/rdm/controller/product_info.c"
+       "${ESP_DMX_ROOT}/src/rdm/controller/device_control.c" "${ESP_DMX_ROOT}/src/rdm/controller/dmx_setup.c"
+       "${ESP_DMX_ROOT}/src/rdm/controller/utils.c"
        
        # RDM responder
-       "src/rdm/responder.c" "src/rdm/responder/discovery.c"
-       "src/rdm/responder/product_info.c" "src/rdm/responder/rdm_info.c"
-       "src/rdm/responder/device_control.c" "src/rdm/responder/queue_status.c"
-       "src/rdm/responder/dmx_setup.c" "src/rdm/responder/sensor_parameter.c"
-       "src/rdm/responder/power_lamp.c" "src/rdm/responder/utils.c"
-  INCLUDE_DIRS "src"
+       "${ESP_DMX_ROOT}/src/rdm/responder.c" "${ESP_DMX_ROOT}/src/rdm/responder/discovery.c"
+       "${ESP_DMX_ROOT}/src/rdm/responder/product_info.c" "${ESP_DMX_ROOT}/src/rdm/responder/rdm_info.c"
+       "${ESP_DMX_ROOT}/src/rdm/responder/device_control.c" "${ESP_DMX_ROOT}/src/rdm/responder/queue_status.c"
+       "${ESP_DMX_ROOT}/src/rdm/responder/dmx_setup.c" "${ESP_DMX_ROOT}/src/rdm/responder/sensor_parameter.c"
+       "${ESP_DMX_ROOT}/src/rdm/responder/power_lamp.c" "${ESP_DMX_ROOT}/src/rdm/responder/utils.c"
+  INCLUDE_DIRS "${ESP_DMX_ROOT}/src"
   REQUIRES driver esp_timer esp_common esp_hw_support nvs_flash
 )   

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ This library can be installed by cloning this repository into your your `Arduino
 
 This library requires ESP-IDF version 4.4.1 or newer. Clone this repository into your project's `components` folder. The library can be linked by writing `#include "esp_dmx.h"` at the top of your `main.c` file.
 
+Inclusion of the library as a compoonent in your ESP-IDF project works by default. If you prefer to locate the library elsewhere it
+is possible to create a simple wrapper component in your project's `components` folder. This wrapper component should contain a `CMakeLists.txt` file with the following content:
+
+```cmake
+set(ESP_DMX_ROOT <path to esp_dmx>)
+include("${ESP_DMX_ROOT}/CMakeLists.txt")
+```
+
+The variable `ESP_DMX_ROOT` will be used to locate source files and includes for the library. Everything else will function as normal.
+
 ### PlatformIO
 
 This library is compatible with the PlatformIO IDE. Search for this library in the PlatformIO library registry and add it to your project. The library can be included by writing `#include "esp_dmx.h"` at the top of your `main.c` or `main.cpp` file.


### PR DESCRIPTION
Hi there.

Thanks a bunch for maintaining this library.

This PR makes it easy to include the library when it is not directly within the `components` directory by simply setting the `ESP_DMX_ROOT` variable before including the `CMakeLists.txt` file.

This allows users to create a simple wrapper component like this:
```cmake
# components/esp_dmx_wrapper/CMakeLists.txt
set(ESP_DMX_ROOT <path to esp_dmx>)
include("${ESP_DMX_ROOT}/CMakeLists.txt")
```

The benefit, to me, is that I can keep all my third-party dependencies / submodules in one place. It makes it easier not to miss one ;)

What do you think?