### PR TITLE
Add functions for retrieving more data from the device

### DIFF
--- a/examples/Arduino_RDMController/Arduino_RDMController.ino
+++ b/examples/Arduino_RDMController/Arduino_RDMController.ino
@@ -108,6 +108,33 @@ void setup() {
                                             softwareVersionLabelSize, &ack)) {
       Serial.printf("Software version label: %s\n", softwareVersionLabel);
     }
+	
+	    /* Also, we will send a request to get the device's manufacturer label.*/
+    char manufacturerLabel[RDM_ASCII_SIZE_MAX];
+    int manufacturerLabelSize = RDM_ASCII_SIZE_MAX;
+    if (rdm_send_get_manufacturer_label(dmxPort, &destUID, subDevice,
+                                            manufacturerLabel,
+                                            manufacturerLabelSize, &ack)) {
+      Serial.printf("Manufacturer label: %s\n", manufacturerLabel);
+    }
+	
+	    /* Also, we will send a request to get the device's model description */
+    char modelDescription[RDM_ASCII_SIZE_MAX];
+    int modelDescriptionSize = RDM_ASCII_SIZE_MAX;
+    if (rdm_send_get_device_model_description(dmxPort, &destUID, subDevice,
+                                            modelDescription,
+                                            modelDescriptionSize, &ack)) {
+      Serial.printf("Model description: %s\n", modelDescription);
+    }
+	
+	    /* Also, we will send a request to get the device's device label */
+    char deviceLabel[RDM_ASCII_SIZE_MAX];
+    int deviceLabelSize = RDM_ASCII_SIZE_MAX;
+    if (rdm_send_get_device_label(dmxPort, &destUID, subDevice,
+                                            deviceLabel,
+                                            deviceLabelSize, &ack)) {
+      Serial.printf("Device label: %s\n", deviceLabel);
+    }
 
     /* Now we will get and set the identify device parameter. Unlike the
       previous two parameters, identify device can be both get and set. We will

--- a/examples/ESPIDF_RDMController/ESPIDF_RDMController.c
+++ b/examples/ESPIDF_RDMController/ESPIDF_RDMController.c
@@ -64,6 +64,32 @@ void app_main() {
                                               sw_label, sw_label_size, &ack)) {
         ESP_LOGI(TAG, "Software version label: %s", sw_label);
       }
+	  
+      // Get the manufacturer label
+      char man_label[33];
+      size_t man_label_size = sizeof(man_label);
+      if (rdm_send_get_manufacturer_label(dmx_num, dest_uid, sub_device,
+                                              man_label, man_label_size, &ack)) {
+        ESP_LOGI(TAG, "Manufacturer label: %s", man_label);
+      }
+	  
+      // Get the device model description
+      char model_desc[33];
+      size_t model_desc_size = sizeof(model_desc);
+      if (rdm_send_get_device_model_description(dmx_num, dest_uid, sub_device,
+                                              model_desc, model_desc_size, &ack)) {
+        ESP_LOGI(TAG, "Model Description: %s", model_desc);
+      }
+	  
+      // Get the device label
+      char dev_label[33];
+      size_t dev_label_size = sizeof(dev_label);
+      if (rdm_send_get_device_label(dmx_num, dest_uid, sub_device,
+                                              dev_label, dev_label_size, &ack)) {
+        ESP_LOGI(TAG, "Device label: %s", dev_label);
+      }
+	  
+	  
 
       // Get and set the identify state
       bool identify;

--- a/keywords.txt
+++ b/keywords.txt
@@ -145,6 +145,9 @@ rdm_send_set_dmx_start_address	KEYWORD2
 # rdm/controller/include/product_info.h
 rdm_send_get_device_info	KEYWORD2
 rdm_send_get_software_version_label	KEYWORD2
+rdm_send_get_manufacturer_label	KEYWORD2
+rdm_send_get_device_model_description	KEYWORD2
+rdm_send_get_device_label	KEYWORD2
 
 # rdm/controller/include/utils.h
 rdm_send_request	KEYWORD2

--- a/src/rdm/controller/include/product_info.h
+++ b/src/rdm/controller/include/product_info.h
@@ -67,7 +67,85 @@ size_t rdm_send_get_software_version_label(dmx_port_t dmx_num,
                                            const rdm_uid_t *dest_uid,
                                            rdm_sub_device_t sub_device,
                                            char *software_version_label,
+/**
+ * @brief Sends an RDM GET manufacturer label request and reads the
+ * response, if any.
+ *
+ * GET manufacturer label are sent without parameter data. If a response is
+ * received, the response parameter data will include the name of the 
+ * manufacturer in the form of a string up to 32 bytes long.
+ *
+ * @param dmx_num The DMX port number.
+ * @param[in] dest_uid A pointer to the UID of the destination.
+ * @param sub_device The sub-device number of the destination.
+ * @param[out] manufacturer_label A pointer to a parameter which will be
+ * received in the response.
+ * @param size The size of the manufacturer_label string. Used to prevent
+ * buffer overflows.
+ * @param[out] ack A pointer to an ACK struct which contains information about
+ * the response, including information if no response is received.
+ * @return true if a properly formatted RDM_RESPONSE_TYPE_ACK was received.
+ * @return false if no response was received, was improperly formatted, or an
+ * RDM_RESPONSE_TYPE_ACK was not received.
+ */                                           size_t size, rdm_ack_t *ack);
+size_t rdm_send_get_manufacturer_label(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *manufacturer_label,
                                            size_t size, rdm_ack_t *ack);
+/**
+ * @brief Sends an RDM GET model description request and reads the
+ * response, if any.
+ *
+ * GET manufacturer label are sent without parameter data. If a response is
+ * received, the response parameter data will include the manufacturer's model
+ * name of the device in the form of a string up to 32 bytes long.
+ *
+ * @param dmx_num The DMX port number.
+ * @param[in] dest_uid A pointer to the UID of the destination.
+ * @param sub_device The sub-device number of the destination.
+ * @param[out] device_model_description A pointer to a parameter which will be
+ * received in the response.
+ * @param size The size of the device_model_description string. Used to prevent
+ * buffer overflows.
+ * @param[out] ack A pointer to an ACK struct which contains information about
+ * the response, including information if no response is received.
+ * @return true if a properly formatted RDM_RESPONSE_TYPE_ACK was received.
+ * @return false if no response was received, was improperly formatted, or an
+ * RDM_RESPONSE_TYPE_ACK was not received.
+ */ 
+size_t rdm_send_get_device_model_description(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *device_model_description,
+                                           size_t size, rdm_ack_t *ack);
+/**
+ * @brief Sends an RDM GET device label request and reads the
+ * response, if any.
+ *
+ * GET manufacturer label are sent without parameter data. If a response is
+ * received, the response parameter data will include the user-defined device
+ * label in the form of a string up to 32 bytes long.
+ *
+ * @param dmx_num The DMX port number.
+ * @param[in] dest_uid A pointer to the UID of the destination.
+ * @param sub_device The sub-device number of the destination.
+ * @param[out] device_label A pointer to a parameter which will be
+ * received in the response.
+ * @param size The size of the device_label string. Used to prevent
+ * buffer overflows.
+ * @param[out] ack A pointer to an ACK struct which contains information about
+ * the response, including information if no response is received.
+ * @return true if a properly formatted RDM_RESPONSE_TYPE_ACK was received.
+ * @return false if no response was received, was improperly formatted, or an
+ * RDM_RESPONSE_TYPE_ACK was not received.
+ */ 
+size_t rdm_send_get_device_label(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *device_label,
+                                           size_t size, rdm_ack_t *ack);
+
 
 #ifdef __cplusplus
 }

--- a/src/rdm/controller/product_info.c
+++ b/src/rdm/controller/product_info.c
@@ -50,4 +50,74 @@ size_t rdm_send_get_software_version_label(dmx_port_t dmx_num,
   const char *format = "a$";
   return rdm_send_request(dmx_num, &request, format, software_version_label,
                           size, ack);
+
+size_t rdm_send_get_manufacturer_label(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *manufacturer_label,
+                                           size_t size, rdm_ack_t *ack) {
+  DMX_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
+  DMX_CHECK(dest_uid != NULL, 0, "dest_uid is null");
+  DMX_CHECK(sub_device < RDM_SUB_DEVICE_MAX || sub_device == RDM_SUB_DEVICE_ALL,
+            0, "sub_device error");
+  DMX_CHECK(manufacturer_label != NULL, 0,
+            "manufacturer_label is null");
+  DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
+
+  const rdm_request_t request = {.dest_uid = dest_uid,
+                                 .sub_device = sub_device,
+                                 .cc = RDM_CC_GET_COMMAND,
+                                 .pid = RDM_PID_MANUFACTURER_LABEL};
+
+  const char *format = "a$";
+  return rdm_send_request(dmx_num, &request, format, manufacturer_label,
+                          size, ack);
+}						  
+						  
+						  
+size_t rdm_send_get_device_model_description(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *device_model_description,
+                                           size_t size, rdm_ack_t *ack) {
+  DMX_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
+  DMX_CHECK(dest_uid != NULL, 0, "dest_uid is null");
+  DMX_CHECK(sub_device < RDM_SUB_DEVICE_MAX || sub_device == RDM_SUB_DEVICE_ALL,
+            0, "sub_device error");
+  DMX_CHECK(device_model_description != NULL, 0,
+            "device_model_description is null");
+  DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
+
+  const rdm_request_t request = {.dest_uid = dest_uid,
+                                 .sub_device = sub_device,
+                                 .cc = RDM_CC_GET_COMMAND,
+                                 .pid = RDM_PID_DEVICE_MODEL_DESCRIPTION};
+
+  const char *format = "a$";
+  return rdm_send_request(dmx_num, &request, format, device_model_description,
+                          size, ack);
+}
+
+
+size_t rdm_send_get_device_label(dmx_port_t dmx_num,
+                                           const rdm_uid_t *dest_uid,
+                                           rdm_sub_device_t sub_device,
+                                           char *device_label,
+                                           size_t size, rdm_ack_t *ack) {
+  DMX_CHECK(dmx_num < DMX_NUM_MAX, 0, "dmx_num error");
+  DMX_CHECK(dest_uid != NULL, 0, "dest_uid is null");
+  DMX_CHECK(sub_device < RDM_SUB_DEVICE_MAX || sub_device == RDM_SUB_DEVICE_ALL,
+            0, "sub_device error");
+  DMX_CHECK(device_label != NULL, 0,
+            "device_label is null");
+  DMX_CHECK(dmx_driver_is_installed(dmx_num), 0, "driver is not installed");
+
+  const rdm_request_t request = {.dest_uid = dest_uid,
+                                 .sub_device = sub_device,
+                                 .cc = RDM_CC_GET_COMMAND,
+                                 .pid = RDM_PID_DEVICE_LABEL};
+
+  const char *format = "a$";
+  return rdm_send_request(dmx_num, &request, format, device_label,
+                          size, ack);
 }

--- a/src/rdm/controller/product_info.c
+++ b/src/rdm/controller/product_info.c
@@ -50,6 +50,8 @@ size_t rdm_send_get_software_version_label(dmx_port_t dmx_num,
   const char *format = "a$";
   return rdm_send_request(dmx_num, &request, format, software_version_label,
                           size, ack);
+}
+
 
 size_t rdm_send_get_manufacturer_label(dmx_port_t dmx_num,
                                            const rdm_uid_t *dest_uid,


### PR DESCRIPTION
There are now functions for the following:
get manufacturer label
get device model description
get device label

These are also now included in the 'RDMController' example, both in Arduino and ESPIDF versions.
Also, these new keywords have been added to keywords.txt