### PR TITLE
Fixed crashing on ESP-C6 / ESP-IDV v5.5.1

### DIFF
--- a/src/dmx/hal/uart.c
+++ b/src/dmx/hal/uart.c
@@ -350,32 +350,19 @@ periph_module_enable(uart_periph_signal[dmx_num].module);
     #endif
 #endif
   }
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-  uint32_t sclk_freq;
-#if CONFIG_IDF_TARGET_ESP32C6
-  // UART2 on C6 is a LP UART, with fixed GPIO pins for tx, rx, and rts
-  if (dmx_num == 2) {
-    LP_CLKRST.lpperi.lp_uart_clk_sel = 0;  // Use LP_UART_SCLK_LP_FAST
-  } else {
-    uart_ll_set_sclk(uart->dev, UART_SCLK_DEFAULT);
-  }
-  uart_get_sclk_freq(UART_SCLK_DEFAULT, &sclk_freq);
-#else
-  uart_ll_set_sclk(uart->dev, UART_SCLK_DEFAULT);
-  uart_get_sclk_freq(UART_SCLK_DEFAULT, &sclk_freq);
-#endif
-  uart_ll_set_baudrate(uart->dev, DMX_BAUD_RATE, sclk_freq);
-#else
-  uart_ll_set_sclk(uart->dev, UART_SCLK_APB);
-  uart_ll_set_baudrate(uart->dev, DMX_BAUD_RATE);
-#endif
-  uart_ll_set_mode(uart->dev, UART_MODE_UART);
-  uart_ll_set_parity(uart->dev, UART_PARITY_DISABLE);
-  uart_ll_set_data_bit_num(uart->dev, UART_DATA_8_BITS);
-  uart_ll_set_stop_bits(uart->dev, UART_STOP_BITS_2);
+
+
+  uart_config_t uart_config = {
+      .baud_rate = 250000,
+      .data_bits = UART_DATA_8_BITS,
+      .parity    = UART_PARITY_DISABLE,
+      .stop_bits = UART_STOP_BITS_2,
+      .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+      .source_clk = UART_SCLK_DEFAULT,
+  };
+  ESP_ERROR_CHECK(uart_param_config(uart->num, &uart_config));
   uart_ll_tx_break(uart->dev, 0);
   uart_ll_set_tx_idle_num(uart->dev, 0);
-  uart_ll_set_hw_flow_ctrl(uart->dev, UART_HW_FLOWCTRL_DISABLE, 0);
   uart_ll_set_txfifo_empty_thr(uart->dev, DMX_UART_EMPTY_DEFAULT);
   uart_ll_set_rxfifo_full_thr(uart->dev, DMX_UART_FULL_DEFAULT);
 

--- a/src/dmx/hal/uart.c
+++ b/src/dmx/hal/uart.c
@@ -29,7 +29,7 @@ static struct dmx_uart_t {
 } dmx_uart_context[DMX_NUM_MAX] = {
     {.num = 0, .dev = UART_LL_GET_HW(0)},
     {.num = 1, .dev = UART_LL_GET_HW(1)},
-#if SOC_UART_NUM > 2
+#if DMX_NUM_MAX > 2
     {.num = 2, .dev = UART_LL_GET_HW(2)},
 #endif
 };
@@ -327,15 +327,27 @@ static void DMX_ISR_ATTR dmx_uart_isr(void *arg) {
 bool dmx_uart_init(dmx_port_t dmx_num, void *isr_context, int isr_flags) {
   struct dmx_uart_t *uart = &dmx_uart_context[dmx_num];
 
-  periph_module_enable(uart_periph_signal[dmx_num].module);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+periph_module_enable(PERIPH_UART0_MODULE+dmx_num);
+#else
+periph_module_enable(uart_periph_signal[dmx_num].module);
+#endif
   if (dmx_num != 0) {  // Default UART port for console
 #if SOC_UART_REQUIRE_CORE_RESET
     // ESP32C3 workaround to prevent UART outputting garbage data
     uart_ll_set_reset_core(uart->dev, true);
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    periph_module_reset(PERIPH_UART0_MODULE+dmx_num);
+    #else
     periph_module_reset(uart_periph_signal[dmx_num].module);
+    #endif
     uart_ll_set_reset_core(uart->dev, false);
 #else
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    periph_module_reset(PERIPH_UART0_MODULE+dmx_num);
+    #else
     periph_module_reset(uart_periph_signal[dmx_num].module);
+    #endif
 #endif
   }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
@@ -381,7 +393,11 @@ bool dmx_uart_init(dmx_port_t dmx_num, void *isr_context, int isr_flags) {
 void dmx_uart_deinit(dmx_port_t dmx_num) {
   struct dmx_uart_t *uart = &dmx_uart_context[dmx_num];
   if (uart->num != 0) {  // Default UART port for console
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    periph_module_disable(PERIPH_UART1_MODULE+dmx_num);
+    #else
     periph_module_disable(uart_periph_signal[uart->num].module);
+    #endif
   }
 }
 


### PR DESCRIPTION
I was getting watchdog errors in the `uart_ll_update()` function because something wasn't updating quite right in the UART section.


This eliminates the custom low-level HAL hacks where possible in the UART init code, and uses the native driver. It seems to work better.